### PR TITLE
Fix the CI to run automatically when PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: Tests and Lint
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ main ]
 
 jobs:
   build:
@@ -22,4 +21,4 @@ jobs:
       run: pip install tox tox-gh-actions
 
     - name: Run Python tests
-      run: make test
+      run: make tests


### PR DESCRIPTION
This commit fixes the CI to run automatically the ci.yml when a PR is
submitted.
Fix the run command for Run Python Tests step.

Closes #23 

Signed-off-by: Kairo de Araujo <kairo@kairo.eti.br>