### PR TITLE
Add requirements and coverage step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,11 @@ reformat:
 
 tests:
 	tox -r
+
+requirements:
+	pipenv lock -r > requirements.txt
+	pipenv lock -r -d > requirements-dev.txt
+
+coverage:
+	coverage report
+	coverage html -i


### PR DESCRIPTION
This PR adds to the Makefile a shortcut for developers to generate the ``requirements.txt`` and ``requirements-dev.txt``

Closes: #25 

Signed-off-by: evertoncss9 <evertoncss@gmail.com>