### PR TITLE
Fixed wrong title in the kaprien-cli

### DIFF
--- a/docs/source/devel/index.rst
+++ b/docs/source/devel/index.rst
@@ -1,13 +1,13 @@
-############################
-kaprien-rest-api Development
-############################
+=======================
+kaprien-cli Development
+=======================
 
 
 .. include:: design.rst
 
 
-kaprien-rest-api component level
---------------------------------
+kaprien-cli component level
+---------------------------
 
 .. uml:: ../../diagrams/kaprien-cli-C3.puml
 .. toctree::


### PR DESCRIPTION
Once reused from kaprien-rest-api structure, the titles in development
were wrong.
Fixed

Signed-off-by: Kairo Araujo <kairo@kairo.eti.br>