### PR TITLE
Add ceremony status

### DIFF
--- a/kaprien/cli/admin/login.py
+++ b/kaprien/cli/admin/login.py
@@ -64,6 +64,7 @@ def _run_login(context):
             "read:bootstrap "
             "read:settings "
             "read:token "
+            "read:tasks "
             "write:token "
         ),
         "expires": expires,

--- a/kaprien/helpers/api_client.py
+++ b/kaprien/helpers/api_client.py
@@ -10,6 +10,7 @@ from kaprien.cli import click
 class URL(Enum):
     token = "api/v1/token/"
     bootstrap = "api/v1/bootstrap/"
+    task = "api/v1/task/?task_id="
 
 
 class Methods(Enum):

--- a/tests/unit/cli/admin/test_ceremony.py
+++ b/tests/unit/cli/admin/test_ceremony.py
@@ -336,7 +336,7 @@ class TestCeremonyGroupCLI:
         )
 
         assert test_result.exit_code == 0
-        assert "Ceremony and Bootstrap done" in test_result.output
+        assert "Ceremony done." in test_result.output
         # passwords not shown in output
         assert "strongPass" not in test_result.output
 


### PR DESCRIPTION
Ceremony uses the kaprien-rest-api tasks to check the Ceremony status.

Closes #50 
Signed-off-by: Kairo de Araujo <kairo@kairo.eti.br>