### PR TITLE
CI/CD Improvements

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,75 @@
+name: CD
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - v*
+
+permissions:
+  contents: write
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.gh-release.outputs.id }}
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+
+      - name: Set up Python
+        uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5
+        with:
+          python-version: '3.x'
+
+      - name: Install build dependency
+        run: python3 -m pip install --upgrade pip build
+
+      - name: Build binary wheel and source tarball
+        run: python3 -m build --sdist --wheel --outdir dist/ .
+
+      - id: gh-release
+        name: Publish GitHub release candiate
+        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
+        with:
+          name: ${{ github.ref_name }}-rc
+          tag_name: ${{ github.ref }}
+          body: "Release waiting for review..."
+          files: dist/*
+
+      - name: Store build artifacts
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
+        # NOTE: The GitHub release page contains the release artifacts too, but using
+        # GitHub upload/download actions seems robuster: there is no need to compute
+        # download URLs and tampering with artifacts between jobs is more limited.
+        with:
+          name: build-artifacts
+          path: dist
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: build
+    environment: release
+    steps:
+      - name: Fetch build artifacts
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
+        with:
+          name: build-artifacts
+          path: dist
+
+      - name: Finalize GitHub release
+        uses: actions/github-script@c713e510dbd7d213d92d41b7a7805a986f4c5c66
+        with:
+          script: |
+            await github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: '${{ needs.build.outputs.release_id }}',
+              name: '${{ github.ref_name }}',
+            })

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,13 @@ jobs:
     - name: Install tox and coverage
       run: pip install tox tox-gh-actions
 
-    # - name: Install Plantuml for docs
-    #   run: |
-    #     sudo apt update
-    #     sudo apt install -y plantuml
-
     - name: Run Python tests
       run: make tests
+
+    - name: Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV}}
+        files: coverage.xml
+        fail_ci_if_error: false
+        verbose: true

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,14 @@
 Kaprien Command Line Interface
 ##############################
 
-This is a Command Line Interface for Kaprien
+|Test Docker Image build| |Tests and Lint| |Coverage|
+
+.. |Tests and Lint| image:: https://github.com/kaprien/kaprien-cli/actions/workflows/ci.yml/badge.svg
+  :target: https://github.com/kaprien/kaprien-cli/actions/workflows/ci.yml
+.. |Coverage| image:: https://codecov.io/gh/kaprien/kaprien-cli/branch/main/graph/badge.svg
+  :target: https://codecov.io/gh/kaprien/kaprien-cli
+
+Kaprien Command Line Interface (CLI). Kaprien CLI is part of Kaprien.
 
 .. note::
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,12 +16,13 @@ commands =
     flake8
     isort -l79 --profile black --check --diff .
     black -l79 --check --diff .
-    # mypy .
+    # mypy . #issue33
 
 [testenv:test]
 allowlist_externals = coverage
 commands =
     coverage run --omit='tests/*' -m pytest -vv
+    coverage xml -i
     coverage report
 
 [testenv:docs]


### PR DESCRIPTION
- adds CD.yml, the possiblility to release versions using the GitHub Actions.
- adds the Coverage in the CI using Codecov
- adds badges to the README.rst

Partial #55 

Signed-off-by: Kairo Araujo <kairo@kairo.eti.br>