### PR TITLE
Fix the documentation for rstuf command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,9 +94,9 @@ Running RSTUF CLI:
 
 .. code:: shell
 
-    $ rstuf-cli
+    $ rstuf
 
-    Usage: rstuf-cli [OPTIONS] COMMAND [ARGS]...
+    Usage: rstuf [OPTIONS] COMMAND [ARGS]...
 
     Repository Service for TUF Command Line Interface (CLI).
 

--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -15,9 +15,9 @@ Using pip:
 
 .. code:: shell
 
-    ❯ rstuf-cli
+    ❯ rstuf
                                                                                                                                                  
-     Usage: rstuf-cli [OPTIONS] COMMAND [ARGS]...                                                                                                  
+     Usage: rstuf [OPTIONS] COMMAND [ARGS]...                                                                                                  
                                                                                                                                                  
      Repository Service for TUF Command Line Interface (CLI).                                                                                        
                                                                                                                                                  
@@ -36,9 +36,9 @@ It executes administrative commands to the Repository Service for TUF.
 
 .. code:: shell
 
-    ❯ rstuf-cli admin
+    ❯ rstuf admin
 
-    Usage: rstuf-cli admin [OPTIONS] COMMAND [ARGS]...
+    Usage: rstuf admin [OPTIONS] COMMAND [ARGS]...
 
     Administrative Commands
 
@@ -60,15 +60,15 @@ such as Ceremony, Token Generation, etc.
 
 .. code:: shell
 
-    ❯ rstuf-cli admin login
-    ╔══════════════════════════════════════════════════════════════════════════════════════════════════╗
-    ║                                 Login to Repository Service for TUF                                  ║
-    ╚══════════════════════════════════════════════════════════════════════════════════════════════════╝
+    ❯ rstuf admin login
+    ╔══════════════════════════════════════════════════════════════════════════════════════╗
+    ║                     Login to Repository Service for TUF                              ║
+    ╚══════════════════════════════════════════════════════════════════════════════════════╝
 
-    ┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
-    │         The server and token will generate a token and it will be                                │
-    │         stored in /Users/kairoaraujo/.rstuf.ini                                                    │
-    └──────────────────────────────────────────────────────────────────────────────────────────────────┘
+    ┌──────────────────────────────────────────────────────────────────────────────────────┐
+    │         The server and token will generate a token and it will be                    │
+    │         stored in /Users/kairoaraujo/.rstuf.ini                                      │
+    └──────────────────────────────────────────────────────────────────────────────────────┘
 
     Server Address: http://192.168.1.199
     Username (admin): admin
@@ -93,29 +93,30 @@ You can do the Ceremony offline. This means on a disconnected computer
 
 .. code:: shell
 
-    ❯ rstuf-cli admin ceremony --help
+    ❯ rstuf admin ceremony --help
                                                                                                                             
-    Usage: rstuf-cli admin ceremony [OPTIONS]                                                                                  
+    Usage: rstuf admin ceremony [OPTIONS]                                                                                  
                                                                                                                             
     Start a new Metadata Ceremony.                                                                                           
                                                                                                                             
-    ╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-    │  --bootstrap  -b        Bootstrap a Repository Service for TUF using the Repository Metadata after Ceremony                │
-    │  --file       -f  TEXT  Generate specific JSON Payload compatible with Repository Service for TUF bootstrap after Ceremony │
-    │                         [default: payload.json]                                                                        │
-    │  --upload     -u        Upload existent payload 'file'. Requires '-b/--bootstrap'. Optional '-f/--file' to use non     │
-    │                         default file.                                                                                  │
-    │  --save       -s        Save a copy of the metadata locally. This option saves the metadata files (json) in the         │
-    │                         'metadata' dir.                                                                                │
-    │                         [default: False]                                                                               │
-    │  --help       -h        Show this message and exit.                                                                    │
-    ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+    ╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────────────────╮
+    │  --bootstrap  -b        Bootstrap a Repository Service for TUF using the Repository Metadata after Ceremony     │
+    │  --file       -f  TEXT  Generate specific JSON Payload compatible with Repository Service for TUF bootstrap     │
+                              after Ceremony                                                                          │
+    │                         [default: payload.json]                                                                 │
+    │  --upload     -u        Upload existent payload 'file'. Requires '-b/--bootstrap'. Optional '-f/--file' to use  │
+    │                         non default file.                                                                       │
+    │  --save       -s        Save a copy of the metadata locally. This option saves the metadata files (json) in the │
+    │                         'metadata' dir.                                                                         │
+    │                         [default: False]                                                                        │
+    │  --help       -h        Show this message and exit.                                                             │
+    ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 
 There are three steps in the Ceremony.
 
 .. note::
 
-    We recommend running the ``rstuf-cli admin ceremony`` to simulate and check
+    We recommend running the ``rstuf admin ceremony`` to simulate and check
     the details of the instructions. It is more detailed.
 
 
@@ -124,7 +125,7 @@ Step 1: Configure the Roles
 
 .. code:: shell
 
-    ❯ rstuf-cli admin ceremony
+    ❯ rstuf admin ceremony
 
     (...)
     Do you want start the ceremony? [y/n]: y
@@ -275,7 +276,7 @@ complete (without the offline keys).
     ║                                  STEP 3: Validate configuration                                  ║
     ╚══════════════════════════════════════════════════════════════════════════════════════════════════╝
 
-    The information below is the configuration done in the preview steps. Check the number of keys, the 
+    The information below is the configuration done in the preview steps. Check the number of keys, the
     threshold/quorum and type of key.
     ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
     ┃       ROLE SUMMARY        ┃                                 KEYS                                 ┃
@@ -361,7 +362,7 @@ If you did the ceremony in a disconnected computer:
 Using another computer with access to ``repository-service-tuf-api``
 1.  Get the generated ``payload.json`` (or the custom name you chose)
 2.  Install ``repository-service-tuf``
-3.  Run ``rstuf-cli admin ceremony -b [-u filename]``
+3.  Run ``rstuf admin ceremony -b [-u filename]``
 
 Token (``token``)
 -----------------
@@ -370,9 +371,9 @@ Token Management
 
 .. code:: shell
 
-    ❯ rstuf-cli admin token
+    ❯ rstuf admin token
                                                                                                                             
-    Usage: rstuf-cli admin token [OPTIONS] COMMAND [ARGS]...                                                                   
+    Usage: rstuf admin token [OPTIONS] COMMAND [ARGS]...                                                                   
                                                                                                                             
     Token Management.                                                                                                        
                                                                                                                             
@@ -390,9 +391,9 @@ Generate tokens to use in integrations.
 
 .. code:: shell
 
-    ❯ rstuf-cli admin token generate -h
+    ❯ rstuf admin token generate -h
                                                                                                         
-    Usage: rstuf-cli admin token generate [OPTIONS]                                                      
+    Usage: rstuf admin token generate [OPTIONS]                                                      
                                                                                                         
     Generate a new token.
                                                                                                         
@@ -408,7 +409,7 @@ Example of usage:
 
 .. code:: shell
 
-    ❯ rstuf-cli admin token generate -s write:targets
+    ❯ rstuf admin token generate -s write:targets
     {
         "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyX
         zFfNTNiYTY4MzAwNTk3NGY2NWIxMDQ5NzczMjIiwicGFzc3dvcmQiOiJiJyQyYiQxMiRxT0
@@ -427,9 +428,9 @@ Show token detailed information.
 
 .. code:: shell
 
-    ❯ rstuf-cli admin token inspect -h
+    ❯ rstuf admin token inspect -h
                                                                                                                             
-    Usage: rstuf-cli admin token inspect [OPTIONS] TOKEN                                                                       
+    Usage: rstuf admin token inspect [OPTIONS] TOKEN                                                                       
                                                                                                                             
     Show token information details.                                                                                          
                                                                                                                             
@@ -437,7 +438,7 @@ Show token detailed information.
     │  --help  -h    Show this message and exit.                                                                             │
     ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 
-    ❯ rstuf-cli admin token inspect eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1...PDwwY
+    ❯ rstuf admin token inspect eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1...PDwwY
     {
     "data": {
         "scopes": [


### PR DESCRIPTION
After the `trs-cli` renaming, it becomes `rstuf`.

For the previous project name TUF Repository Service (TRS) the name `trs` was named `trs-cli` to avoid conflict with Linux `trs` command for filer replacing strings.

The project's Repository Service for TUF (RSTUF) simplifies to `rstuf`. The code and tests are correct, but the documentation was wrong.

Closes: #77

Signed-off-by: Kairo de Araujo <kairo@kairo.eti.br>