### PR TITLE
Add PyPI publishing in GH workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,13 +35,16 @@ jobs:
           python-version: '3.x'
 
       - name: Install build dependency
-        run: python3 -m pip install --upgrade pip build
+        run: python3 -m pip install --upgrade pip build twine
 
       - name: Build binary wheel and source tarball
         run: python3 -m build --sdist --wheel --outdir dist/ .
 
+      - name: Check distribution's long description rendering on PyPI
+        run: twine check dist/*
+
       - id: gh-release
-        name: Publish GitHub release candiate
+        name: Publish GitHub release candidate
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
         with:
           name: ${{ github.ref_name }}-rc
@@ -80,3 +83,12 @@ jobs:
               release_id: '${{ needs.build.outputs.release_id }}',
               name: '${{ github.ref_name }}',
             })
+
+      - name: Publish binary wheel and source tarball 📦 on PyPI
+        # Only attempt PyPI upload in upstream repository
+        if: github.repository == 'vmware/repository-service-tuf-cli'
+        uses: pypa/gh-action-pypi-publish@0bf742be3ebe032c25dd15117957dc15d0cfc38d
+        with:
+          # TODO: Replace secret's name with the repo's one for PyPI (in
+          # Settings -> Security -> Secrets and variables -> Actions)
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -84,6 +84,13 @@ jobs:
               name: '${{ github.ref_name }}',
             })
 
+      - name: Publish distribution 📦 to Test PyPI
+        if: github.repository == 'vmware/repository-service-tuf-cli'
+        uses: pypa/gh-action-pypi-publish@0bf742be3ebe032c25dd15117957dc15d0cfc38d
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
+
       - name: Publish binary wheel and source tarball 📦 on PyPI
         # Only attempt PyPI upload in upstream repository
         if: github.repository == 'vmware/repository-service-tuf-cli'

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -96,6 +96,4 @@ jobs:
         if: github.repository == 'vmware/repository-service-tuf-cli'
         uses: pypa/gh-action-pypi-publish@0bf742be3ebe032c25dd15117957dc15d0cfc38d
         with:
-          # TODO: Replace secret's name with the repo's one for PyPI (in
-          # Settings -> Security -> Secrets and variables -> Actions)
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -66,6 +66,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     environment: release
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
       - name: Fetch build artifacts
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
@@ -85,15 +87,18 @@ jobs:
             })
 
       - name: Publish distribution 📦 to Test PyPI
-        if: github.repository == 'vmware/repository-service-tuf-cli'
+        env:
+          name: testpypi
+          url: https://pypi.org/p/repository-service-tuf
+        if: github.repository == 'repository-service-tuf/repository-service-tuf-cli'
         uses: pypa/gh-action-pypi-publish@0bf742be3ebe032c25dd15117957dc15d0cfc38d
         with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish binary wheel and source tarball 📦 on PyPI
+        env:
+          name: pypi
+          url: https://pypi.org/p/repository-service-tuf
         # Only attempt PyPI upload in upstream repository
-        if: github.repository == 'vmware/repository-service-tuf-cli'
+        if: github.repository == 'repository-service-tuf/repository-service-tuf-cli'
         uses: pypa/gh-action-pypi-publish@0bf742be3ebe032c25dd15117957dc15d0cfc38d
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
The process of publishing the package to PyPI will now be automated.
TODO: Replace secret's name with the repo's one for PyPI (in -> Security -> Secrets and variables -> Actions)


Note: If we want we can test this first before merging by releasing to TestPyPI (will need a new token with project scope).

Closes #238 