### PR TITLE
Add ft when pr is approved

### DIFF
--- a/.github/workflows/reviewd-ft.yml
+++ b/.github/workflows/reviewd-ft.yml
@@ -1,0 +1,14 @@
+name: Functional Tests
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  functional-latest:
+    if: github.event.review.state == 'approved'
+    uses: vmware/repository-service-tuf/.github/workflows/functional.yml@main
+    with:
+      worker_version: dev
+      api_version: dev
+      cli_version: dev


### PR DESCRIPTION
This commits a new workflow.
When a PR is approved, it will trigger the FT tests.

In this way, before merging, the PR maintainers can check how the PR
changes the functionality in all RSTUF components.

The failure of this test is not a non-go for merge, but it shows
possible problems.