### PR TITLE
Move RSTUF to github.com/repository-service-tuf

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: I need help
-    url: https://github.com/vmware/repository-service-tuf
+    url: https://github.com/repository-service-tuf/repository-service-tuf
     about: If you have questions or need help

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -50,7 +50,7 @@ Getting the source code
 -----------------------
 
 `Fork <https://docs.github.com/en/get-started/quickstart/fork-a-repo>`_ the
-repository on `GitHub <https://github.com/vmware/repository-service-tuf-cli>`_ and
+repository on `GitHub <https://github.com/repository-service-tuf/repository-service-tuf-cli>`_ and
 `clone <https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository>`_
 it to your local machine:
 
@@ -65,7 +65,7 @@ you stay up-to-date with our repository:
 
 .. code-block:: console
 
-    git remote add upstream https://github.com/vmware/repository-service-tuf-cli
+    git remote add upstream https://github.com/repository-service-tuf/repository-service-tuf-cli
     git checkout main
     git fetch upstream
     git merge upstream/main

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ Repository Service for TUF Command Line Interface
 
 |Tests and Lint| |Coverage|
 
-.. |Tests and Lint| image:: https://github.com/vmware/repository-service-tuf-cli/actions/workflows/ci.yml/badge.svg
-  :target: https://github.com/vmware/repository-service-tuf-cli/actions/workflows/ci.yml
+.. |Tests and Lint| image:: https://github.com/repository-service-tuf/repository-service-tuf-cli/actions/workflows/ci.yml/badge.svg
+  :target: https://github.com/repository-service-tuf/repository-service-tuf-cli/actions/workflows/ci.yml
 .. |Coverage| image:: https://codecov.io/gh/vmware/repository-service-tuf-cli/branch/main/graph/badge.svg
   :target: https://codecov.io/gh/vmware/repository-service-tuf-cli
 
@@ -42,9 +42,9 @@ Contributing
 Please, visit the `Repository Service for TUF Development Guide
 <https://repository-service-tuf.readthedocs.io/en/latest/devel/index.html#development-guide>`_.
 
-Check our `CONTRIBUTING.rst <https://github.com/vmware/repository-service-tuf-cli/blob/main/CONTRIBUTING.rst>`_
+Check our `CONTRIBUTING.rst <https://github.com/repository-service-tuf/repository-service-tuf-cli/blob/main/CONTRIBUTING.rst>`_
 for more details on how to contribute to this repository.
 
 License
 =======
-`MIT <https://github.com/vmware/repository-service-tuf-cli/blob/main/LICENSE>`_
+`MIT <https://github.com/repository-service-tuf/repository-service-tuf-cli/blob/main/LICENSE>`_

--- a/tests/unit/cli/admin/test_ceremony.py
+++ b/tests/unit/cli/admin/test_ceremony.py
@@ -735,7 +735,7 @@ class TestCeremonyOptions:
                 "fake_task_id", test_context["settings"], "Bootstrap status: "
             )
         ]
-        # test regression https://github.com/vmware/repository-service-tuf-cli/pull/259  # noqa
+        # test regression https://github.com/repository-service-tuf/repository-service-tuf-cli/pull/259  # noqa
         assert test_context["settings"].SERVER is not None
 
     def test_ceremony_option_bootstrap_upload_no_auth(


### PR DESCRIPTION
It is part of the process moving RSTUF to OpenSSF organization.