### PR TITLE
Bootstrap: add key names option and do a small refactor

### DIFF
--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -222,6 +222,7 @@ Step 2: Load the Online Key
     Choose 1/1 ONLINE key type [ed25519/ecdsa/rsa] (ed25519):
     Enter 1/1 the ONLINE`s private key path: tests/files/online.key
     Enter 1/1 the ONLINE`s private key password:
+    You can give a name to the key to have a reference in future:
     ✅ Key 1/1 Verified
 
     Step 3: Validate the information/settings
@@ -258,11 +259,13 @@ to load their keys.
     Choose 1/2 root key type [ed25519/ecdsa/rsa] (ed25519):
     Enter 1/2 the root`s private key path: tests/files/JanisJoplin.key
     Enter 1/2 the root`s private key password:
+    You can give a name to the key to have a reference in future:
     ✅ Key 1/2 Verified
 
     Choose 2/2 root key type [ed25519/ecdsa/rsa] (ed25519):
     Enter 2/2 the root`s private key path: tests/files/JimiHendrix.key
     Enter 2/2 the root`s private key password:
+    You can give a name to the key to have a reference in future:
     ✅ Key 2/2 Verified
 
 Step 4: Validate Configuration

--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -222,7 +222,7 @@ Step 2: Load the Online Key
     Choose 1/1 ONLINE key type [ed25519/ecdsa/rsa] (ed25519):
     Enter 1/1 the ONLINE`s private key path: tests/files/online.key
     Enter 1/1 the ONLINE`s private key password:
-    You can give a name to the key to have a reference in future:
+    [Optional] Give a name/tag to the key:
     ✅ Key 1/1 Verified
 
     Step 3: Validate the information/settings
@@ -259,13 +259,13 @@ to load their keys.
     Choose 1/2 root key type [ed25519/ecdsa/rsa] (ed25519):
     Enter 1/2 the root`s private key path: tests/files/JanisJoplin.key
     Enter 1/2 the root`s private key password:
-    You can give a name to the key to have a reference in future:
+    [Optional] Give a name/tag to the key:
     ✅ Key 1/2 Verified
 
     Choose 2/2 root key type [ed25519/ecdsa/rsa] (ed25519):
     Enter 2/2 the root`s private key path: tests/files/JimiHendrix.key
     Enter 2/2 the root`s private key password:
-    You can give a name to the key to have a reference in future:
+    [Optional] Give a name/tag to the key:
     ✅ Key 2/2 Verified
 
 Step 4: Validate Configuration

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,17 +82,17 @@ def test_inputs() -> Tuple[List[str], List[str], List[str], List[str]]:
         "",  # Choose 1/1 ONLINE key type [ed25519/ecdsa/rsa]
         "tests/files/key_storage/online.key",  # Enter 1/1 the ONLINE`s private key path  # noqa
         "strongPass",  # Enter 1/1 the ONLINE`s private key password,
-        "",  # You can give a name to the key to have a reference in future:
+        "",  # [Optional] Give a name/tag to the key:
     ]
     input_step3 = [
         "",  # Choose 1/2 root key type [ed25519/ecdsa/rsa]
         "tests/files/key_storage/JanisJoplin.key",  # Enter 1/2 the root`s private key path  # noqa
         "strongPass",  # Enter 1/2 the root`s private key password
-        "",  # You can give a name to the key to have a reference in future:
+        "",  # [Optional] Give a name/tag to the key:
         "",  # Choose 2/2 root key type [ed25519/ecdsa/rsa]
         "tests/files/key_storage/JimiHendrix.key",  # Enter 2/2 the root`s private key path  # noqa
         "strongPass",  # Enter 2/2 the root`s private key password:
-        "",  # You can give a name to the key to have a reference in future:
+        "",  # [Optional] Give a name/tag to the key:
     ]
     input_step4 = [
         "y",  # Is the online key configuration correct? [y/n]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,7 @@ def test_setup() -> BootstrapSetup:
             Roles.ROOT: 1,
             Roles.TARGETS: 1,
         },
-        root_keys=[],
+        root_keys={},
         online_key=RSTUFKey(),
     )
 
@@ -81,15 +81,18 @@ def test_inputs() -> Tuple[List[str], List[str], List[str], List[str]]:
     input_step2 = [
         "",  # Choose 1/1 ONLINE key type [ed25519/ecdsa/rsa]
         "tests/files/key_storage/online.key",  # Enter 1/1 the ONLINE`s private key path  # noqa
-        "strongPass",  # Enter 1/1 the ONLINE`s private key password
+        "strongPass",  # Enter 1/1 the ONLINE`s private key password,
+        "",  # You can give a name to the key to have a reference in future:
     ]
     input_step3 = [
         "",  # Choose 1/2 root key type [ed25519/ecdsa/rsa]
-        "tests/files/key_storage/JanisJoplin.key",  # Enter 1/2 the root`s private key pathh  # noqa
+        "tests/files/key_storage/JanisJoplin.key",  # Enter 1/2 the root`s private key path  # noqa
         "strongPass",  # Enter 1/2 the root`s private key password
+        "",  # You can give a name to the key to have a reference in future:
         "",  # Choose 2/2 root key type [ed25519/ecdsa/rsa]
-        "tests/files/key_storage/JimiHendrix.key",  # Enter 2/2 the root`s private key pathh  # noqa
+        "tests/files/key_storage/JimiHendrix.key",  # Enter 2/2 the root`s private key path  # noqa
         "strongPass",  # Enter 2/2 the root`s private key password:
+        "",  # You can give a name to the key to have a reference in future:
     ]
     input_step4 = [
         "y",  # Is the online key configuration correct? [y/n]

--- a/tests/unit/cli/admin/test_ceremony.py
+++ b/tests/unit/cli/admin/test_ceremony.py
@@ -396,12 +396,12 @@ class TestCeremonyInteraction:
             "",  # Choose 1/1 ONLINE key type [ed25519/ecdsa/rsa]
             "tests/files/key_storage/online.key",  # Enter 1/1 the ONLINE`s private key path  # noqa
             "wrong password",  # Enter 1/1 the ONLINE`s private key password
-            "",  # You can give a name to the key to have a reference in future:  # noqa
+            "",  # [Optional] Give a name/tag to the key
             "y",  # Try again?
             "",  # Choose 1/1 ONLINE key type [ed25519/ecdsa/rsa]
             "tests/files/key_storage/online.key",  # Enter 1/1 the ONLINE`s private key path  # noqa
             "strongPass",  # Enter 1/1 the ONLINE`s private key password
-            "",  # You can give a name to the key to have a reference in future:  # noqa
+            "",  # [Optional] Give a name/tag to the key
         ]
 
         test_result = client.invoke(
@@ -428,7 +428,7 @@ class TestCeremonyInteraction:
             "",  # Choose 1/1 ONLINE key type [ed25519/ecdsa/rsa]
             "tests/files/key_storage/online.key",  # Enter 1/1 the ONLINE`s private key path  # noqa
             "wrong password",  # Enter 1/1 the ONLINE`s private key password
-            "",  # You can give a name to the key to have a reference in future:  # noqa
+            "",  # [Optional] Give a name/tag to the key
             "n",  # Try again?
         ]
 
@@ -455,17 +455,17 @@ class TestCeremonyInteraction:
             "",  # Choose 1/1 ONLINE key type [ed25519/ecdsa/rsa]
             "tests/files/key_storage/online.key",  # Enter 1/1 the ONLINE`s private key path  # noqa
             "strongPass",  # Enter 1/1 the ONLINE`s private key password,
-            "Online key",  # You can give a name to the key to have a reference in future:  # noqa
+            "Online key",  # [Optional] Give a name/tag to the key
         ]
         input_step3 = [
             "",  # Choose 1/2 root key type [ed25519/ecdsa/rsa]
             "tests/files/key_storage/JanisJoplin.key",  # Enter 1/2 the root`s private key path  # noqa
             "strongPass",  # Enter 1/2 the root`s private key password
-            "Martin's Key",  # You can give a name to the key to have a reference in future:  # noqa
+            "Martin's Key",  # [Optional] Give a name/tag to the key
             "",  # Choose 2/2 root key type [ed25519/ecdsa/rsa]
             "tests/files/key_storage/JimiHendrix.key",  # Enter 2/2 the root`s private key path  # noqa
             "strongPass",  # Enter 2/2 the root`s private key password:
-            "Steven's Key",  # You can give a name to the key to have a reference in future:  # noqa
+            "Steven's Key",  # [Optional] Give a name/tag to the key
         ]
 
         test_result = client.invoke(
@@ -492,15 +492,15 @@ class TestCeremonyInteraction:
             "",  # Choose 1/2 root key type [ed25519/ecdsa/rsa]
             "tests/files/key_storage/online.key",  # Enter 1/2 the root`s private key path  # noqa
             "strongPass",  # Enter 1/2 the root`s private key password
-            "",  # You can give a name to the key to have a reference in future:  # noqa
+            "",  # [Optional] Give a name/tag to the key
             "",  # Choose 1/2 root key type [ed25519/ecdsa/rsa]
             "tests/files/key_storage/JanisJoplin.key",  # Enter 1/2 the root`s private key path  # noqa
             "strongPass",  # Enter 1/2 the root`s private key password
-            "",  # You can give a name to the key to have a reference in future:  # noqa
+            "",  # [Optional] Give a name/tag to the key
             "",  # Choose 2/2 root key type [ed25519/ecdsa/rsa]
             "tests/files/key_storage/JimiHendrix.key",  # Enter 2/2 the root`s private key path  # noqa
             "strongPass",  # Enter 2/2 the root`s private key password:
-            "",  # You can give a name to the key to have a reference in future:  # noqa
+            "",  # [Optional] Give a name/tag to the key
         ]
 
         test_result = client.invoke(
@@ -530,7 +530,7 @@ class TestCeremonyInteraction:
             "rsa",  # Choose 1/1 ONLINE key type [ed25519/ecdsa/rsa]
             "tests/files/key_storage/online-rsa.key",  # Enter 1/1 the ONLINE`s private key path  # noqa
             "strongPass",  # Enter 1/1 the ONLINE`s private key password
-            "",  # You can give a name to the key to have a reference in future:  # noqa
+            "",  # [Optional] Give a name/tag to the key
             "y",  # Is the online key configuration correct? [y/n]
             "y",  # Is the root configuration correct? [y/n]
             "y",  # Is the targets configuration correct? [y/n]
@@ -570,7 +570,7 @@ class TestCeremonyInteraction:
             "",  # Choose 1/1 root key type [ed25519/ecdsa/rsa]
             "tests/files/key_storage/JanisJoplin.key",  # Enter 1/1 the root`s private key path  # noqa
             "strongPass",  # Enter 1/2 the root`s private key password
-            "",  # You can give a name to the key to have a reference in future:  # noqa
+            "",  # [Optional] Give a name/tag to the key
             "y",  # Is the root configuration correct? [y/n]
             "y",  # Is the targets configuration correct? [y/n]
             "y",  # Is the snapshot configuration correct? [y/n]

--- a/tests/unit/cli/admin/test_ceremony.py
+++ b/tests/unit/cli/admin/test_ceremony.py
@@ -16,7 +16,7 @@ class TestCeremonyFunctions:
         assert result is False
 
     def test__key_already_in_use_exists_in_role(self, test_setup):
-        test_setup.root_keys = [ceremony.RSTUFKey(key={"keyid": "ema"})]
+        test_setup.root_keys["ema"] = ceremony.RSTUFKey(key={"keyid": "ema"})
         ceremony.setup = test_setup
         result = ceremony._key_already_in_use({"keyid": "ema"})
         assert result is True
@@ -36,7 +36,7 @@ class TestCeremonyFunctions:
         )
 
         result = ceremony._load_key(
-            "/p/key", KeyType.KEY_TYPE_ED25519.value, "pwd"
+            "/p/key", KeyType.KEY_TYPE_ED25519.value, "pwd", None
         )
         assert result == ceremony.RSTUFKey({"keyid": "ema"}, "/p/key", None)
         assert ceremony.import_privatekey_from_file.calls == [
@@ -51,7 +51,7 @@ class TestCeremonyFunctions:
         )
 
         result = ceremony._load_key(
-            "/p/key", KeyType.KEY_TYPE_ED25519.value, "pwd"
+            "/p/key", KeyType.KEY_TYPE_ED25519.value, "pwd", None
         )
         assert result == ceremony.RSTUFKey(
             {},
@@ -69,7 +69,7 @@ class TestCeremonyFunctions:
             pretend.raiser(OSError("permission denied")),
         )
         result = ceremony._load_key(
-            "/p/key", KeyType.KEY_TYPE_ED25519.value, "pwd"
+            "/p/key", KeyType.KEY_TYPE_ED25519.value, "pwd", None
         )
         assert result == ceremony.RSTUFKey(
             {}, None, error=":cross_mark: [red]Failed[/]: permission denied"
@@ -396,10 +396,12 @@ class TestCeremonyInteraction:
             "",  # Choose 1/1 ONLINE key type [ed25519/ecdsa/rsa]
             "tests/files/key_storage/online.key",  # Enter 1/1 the ONLINE`s private key path  # noqa
             "wrong password",  # Enter 1/1 the ONLINE`s private key password
+            "",  # You can give a name to the key to have a reference in future:  # noqa
             "y",  # Try again?
             "",  # Choose 1/1 ONLINE key type [ed25519/ecdsa/rsa]
             "tests/files/key_storage/online.key",  # Enter 1/1 the ONLINE`s private key path  # noqa
             "strongPass",  # Enter 1/1 the ONLINE`s private key password
+            "",  # You can give a name to the key to have a reference in future:  # noqa
         ]
 
         test_result = client.invoke(
@@ -426,6 +428,7 @@ class TestCeremonyInteraction:
             "",  # Choose 1/1 ONLINE key type [ed25519/ecdsa/rsa]
             "tests/files/key_storage/online.key",  # Enter 1/1 the ONLINE`s private key path  # noqa
             "wrong password",  # Enter 1/1 the ONLINE`s private key password
+            "",  # You can give a name to the key to have a reference in future:  # noqa
             "n",  # Try again?
         ]
 
@@ -442,6 +445,42 @@ class TestCeremonyInteraction:
         # passwords not shown in output
         assert "strongPass" not in test_result.output
 
+    def test_ceremony_key_with_name(
+        self, client, test_context, test_inputs, test_setup
+    ):
+        # Test a case when the user gives custom names to the keys.
+        ceremony.setup = test_setup
+        input_step1, input_step2, input_step3, input_step4 = test_inputs
+        input_step2 = [
+            "",  # Choose 1/1 ONLINE key type [ed25519/ecdsa/rsa]
+            "tests/files/key_storage/online.key",  # Enter 1/1 the ONLINE`s private key path  # noqa
+            "strongPass",  # Enter 1/1 the ONLINE`s private key password,
+            "Online key",  # You can give a name to the key to have a reference in future:  # noqa
+        ]
+        input_step3 = [
+            "",  # Choose 1/2 root key type [ed25519/ecdsa/rsa]
+            "tests/files/key_storage/JanisJoplin.key",  # Enter 1/2 the root`s private key path  # noqa
+            "strongPass",  # Enter 1/2 the root`s private key password
+            "Martin's Key",  # You can give a name to the key to have a reference in future:  # noqa
+            "",  # Choose 2/2 root key type [ed25519/ecdsa/rsa]
+            "tests/files/key_storage/JimiHendrix.key",  # Enter 2/2 the root`s private key path  # noqa
+            "strongPass",  # Enter 2/2 the root`s private key password:
+            "Steven's Key",  # You can give a name to the key to have a reference in future:  # noqa
+        ]
+
+        test_result = client.invoke(
+            ceremony.ceremony,
+            input="\n".join(
+                input_step1 + input_step2 + input_step3 + input_step4
+            ),
+            obj=test_context,
+        )
+
+        assert test_result.exit_code == 0, test_result.output
+        assert "Ceremony done. 🔐 🎉." in test_result.output
+        # passwords not shown in output
+        assert "strongPass" not in test_result.output
+
     def test_ceremony_key_duplicated_try_again_yes(
         self, client, test_context, test_inputs, test_setup
     ):
@@ -453,12 +492,15 @@ class TestCeremonyInteraction:
             "",  # Choose 1/2 root key type [ed25519/ecdsa/rsa]
             "tests/files/key_storage/online.key",  # Enter 1/2 the root`s private key path  # noqa
             "strongPass",  # Enter 1/2 the root`s private key password
+            "",  # You can give a name to the key to have a reference in future:  # noqa
             "",  # Choose 1/2 root key type [ed25519/ecdsa/rsa]
             "tests/files/key_storage/JanisJoplin.key",  # Enter 1/2 the root`s private key path  # noqa
             "strongPass",  # Enter 1/2 the root`s private key password
+            "",  # You can give a name to the key to have a reference in future:  # noqa
             "",  # Choose 2/2 root key type [ed25519/ecdsa/rsa]
             "tests/files/key_storage/JimiHendrix.key",  # Enter 2/2 the root`s private key path  # noqa
             "strongPass",  # Enter 2/2 the root`s private key password:
+            "",  # You can give a name to the key to have a reference in future:  # noqa
         ]
 
         test_result = client.invoke(
@@ -488,6 +530,7 @@ class TestCeremonyInteraction:
             "rsa",  # Choose 1/1 ONLINE key type [ed25519/ecdsa/rsa]
             "tests/files/key_storage/online-rsa.key",  # Enter 1/1 the ONLINE`s private key path  # noqa
             "strongPass",  # Enter 1/1 the ONLINE`s private key password
+            "",  # You can give a name to the key to have a reference in future:  # noqa
             "y",  # Is the online key configuration correct? [y/n]
             "y",  # Is the root configuration correct? [y/n]
             "y",  # Is the targets configuration correct? [y/n]
@@ -527,6 +570,7 @@ class TestCeremonyInteraction:
             "",  # Choose 1/1 root key type [ed25519/ecdsa/rsa]
             "tests/files/key_storage/JanisJoplin.key",  # Enter 1/1 the root`s private key path  # noqa
             "strongPass",  # Enter 1/2 the root`s private key password
+            "",  # You can give a name to the key to have a reference in future:  # noqa
             "y",  # Is the root configuration correct? [y/n]
             "y",  # Is the targets configuration correct? [y/n]
             "y",  # Is the snapshot configuration correct? [y/n]


### PR DESCRIPTION
Add a question asking the user if he wants to provide a name for his key.
This will be useful when showing information about roles later during the validation phase.
It will be also useful when showing the keys information during metadata update.

Additionally, I noticed that if I make BootstrapSetup.root_keys as a dict instead of a list this could 
simplify some of our existing functions and a new one that I added when asking for key names.

This feature will be used in my pr for #232 and it's good if we merge it before merging the solution for #232.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>