### PR TITLE
Adapt `flake8` exclude configs to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
   rev: '6.0.0'
   hooks:
   - id: flake8
-    exclude: repository_service_tuf/__init__.py|venv|.venv|setting.py|.git|.tox|dist|docs|/*lib/python*|/*egg|build|tools
+    exclude: docs
 - repo: https://github.com/PyCQA/isort
   rev: '5.12.0'
   hooks:

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,6 @@ isolated_build = true
 envlist = py39,py310,py311,lint,typing,requirements,test
 skipsdist = true
 
-
-[flake8]
-exclude = repository_service_tuf/__init__.py,venv,.venv,settings.py,.git,.tox,dist,docs,*lib/python*,*egg,build,tools
-
 [testenv]
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/requirements-dev.txt


### PR DESCRIPTION
See similar PR: https://github.com/repository-service-tuf/repository-service-tuf-api/pull/286

- Removed the "exclude" settings of `flake8` from `tox.ini` because they were overiding the
ones in `.pre-commit-config.yaml`

- Redefined the files/dirs to be excluded for `flake8` in `.pre-commit-config.yaml`. Specifically:
	- took into account that the patterns for `exclude` are python regular expressions and are matched with `re.search`, and not globals as for `tox`. (see https://pre-commit.com/#regular-expressions)
	- `pre-commit` won’t ever pass untracked files to `flake8` so excluding files that are in `.gitignore` is unecessary (e.g., `.venv`, `venv`, `.tox`, etc.). See https://flake8.pycqa.org/en/latest/user/using-hooks.html#usage-with-the-pre-commit-git-hooks-framework