### PR TITLE
Remove username prompt `rstuf admin login`

### DIFF
--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -80,8 +80,7 @@ such as Ceremony, Token Generation, etc.
     └──────────────────────────────────────────────────────────────────────────────────────┘
 
     Server Address: http://192.168.1.199
-    Username (admin): admin
-    Password:
+    Password for admin:
     Expire (in hours): 2
     Token stored in /Users/kairoaraujo/.repository_service_tuf.ini
 

--- a/repository_service_tuf/cli/admin/login.py
+++ b/repository_service_tuf/cli/admin/login.py
@@ -27,7 +27,7 @@ def _login(server: str, data: Dict[str, str]):
     return token_response.json()
 
 
-def _run_login(context, server_, user_, password_, expires_):
+def _run_login(context, server_, password_, expires_):
     settings = context.obj.get("settings")
     console.print(
         markdown.Markdown(
@@ -55,15 +55,10 @@ def _run_login(context, server_, user_, password_, expires_):
         else:
             break
 
-    if user_ is None:
-        username = prompt.Prompt.ask(
-            "Username", default="admin", show_default=True
-        )
-    else:
-        username = user_
+    username = "admin"
 
     if password_ is None:
-        password = click.prompt("Password", hide_input=True)
+        password = click.prompt(f"Password for {username}", hide_input=True)
     else:
         password = password_
 
@@ -103,13 +98,12 @@ def _run_login(context, server_, user_, password_, expires_):
     "-f", "--force", "force", help="Force login/Renew token", is_flag=True
 )
 @click.option("-s", "server_", help="Server", required=False, default=None)
-@click.option("-u", "user_", help="User", required=False, default=None)
 @click.option("-p", "password_", help="Password", required=False, default=None)
 @click.option(
     "-e", "expires_", help="Expires in Hours", required=False, default=None
 )
 @click.pass_context
-def login(context, force, server_, user_, password_, expires_):
+def login(context, force, server_, password_, expires_):
     """
     Login to Repository Service for TUF (API).
     """
@@ -125,7 +119,7 @@ def login(context, force, server_, user_, password_, expires_):
     ):
         response = is_logged(settings)
         if response.state is False:
-            _run_login(context, server_, user_, password_, expires_)
+            _run_login(context, server_, password_, expires_)
 
         else:
             data = response.data
@@ -136,4 +130,4 @@ def login(context, force, server_, user_, password_, expires_):
                 )
 
     else:
-        _run_login(context, server_, user_, password_, expires_)
+        _run_login(context, server_, password_, expires_)

--- a/tests/unit/cli/admin/test_login.py
+++ b/tests/unit/cli/admin/test_login.py
@@ -55,7 +55,6 @@ class TestLoginGroupCLI:
     def test_login(self, client, test_context):
         steps = [
             "http://test-rstuf",
-            "admin",
             "pass",
             "1",
         ]
@@ -82,7 +81,6 @@ class TestLoginGroupCLI:
     def test_login_no_auth(self, client, test_context):
         steps = [
             "http://test-rstuf",
-            "admin",
             "pass",
             "1",
         ]
@@ -106,7 +104,6 @@ class TestLoginGroupCLI:
 
         steps = [
             "http://test-rstuf",
-            "admin",
             "pass",
             "1",
         ]
@@ -137,7 +134,6 @@ class TestLoginGroupCLI:
 
         steps = [
             "http://test-rstuf",
-            "admin",
             "pass",
             "1",
         ]
@@ -175,7 +171,6 @@ class TestLoginGroupCLI:
 
         steps = [
             "http://test-rstuf",
-            "admin",
             "pass",
             "1",
         ]
@@ -211,7 +206,6 @@ class TestLoginGroupCLI:
         steps = [
             "test-rstuf",
             "http://test-rstuf",
-            "admin",
             "pass",
             "1",
         ]
@@ -232,7 +226,6 @@ class TestLoginGroupCLI:
 
     def test_login_with_server(self, client, test_context):
         steps = [
-            "admin",
             "pass",
             "1",
         ]
@@ -262,7 +255,6 @@ class TestLoginGroupCLI:
 
     def test_login_with_server_bad_address(self, client, test_context):
         steps = [
-            "admin",
             "pass",
             "1",
         ]
@@ -289,7 +281,6 @@ class TestLoginGroupCLI:
     ):
         steps = [
             "http://test-rstuf",
-            "admin",
             "pass",
             "1",
         ]
@@ -305,35 +296,6 @@ class TestLoginGroupCLI:
         test_result = client.invoke(
             login.login,
             ["-s", "test-rstuf"],
-            input="\n".join(steps),
-            obj=test_context,
-        )
-
-        assert test_result.exit_code == 0
-        assert "Login successful." in test_result.output
-        assert login.loaders.write.calls == [
-            pretend.call(
-                test_context["config"], test_context["settings"].to_dict()
-            )
-        ]
-
-    def test_login_with_server_user(self, client, test_context):
-        steps = [
-            "pass",
-            "1",
-        ]
-        login._login = pretend.call_recorder(
-            lambda *a: {"access_token": "fake-token"}
-        )
-
-        login.loaders = pretend.stub(
-            write=pretend.call_recorder(lambda *a: None)
-        )
-        test_context["settings"].AUTH = True
-
-        test_result = client.invoke(
-            login.login,
-            ["-s", "http://test-rstuf", "-u", "admin"],
             input="\n".join(steps),
             obj=test_context,
         )
@@ -362,7 +324,7 @@ class TestLoginGroupCLI:
 
         test_result = client.invoke(
             login.login,
-            ["-s", "http://test-rstuf", "-u", "admin", "-p", "pass"],
+            ["-s", "http://test-rstuf", "-p", "pass"],
             input="\n".join(steps),
             obj=test_context,
         )
@@ -390,8 +352,6 @@ class TestLoginGroupCLI:
             [
                 "-s",
                 "http://test-rstuf",
-                "-u",
-                "admin",
                 "-p",
                 "pass",
                 "-e",


### PR DESCRIPTION
Remove username prompt from `rstuf admin login`

RSTUF has a unique username, `admin`, and uses it for a simple auth in the RSTUF API. We simplify it by removing the username prompt.

Closes #242