### PR TITLE
Fix rstuf admin ceremony -b -u behaviour

### DIFF
--- a/repository_service_tuf/cli/admin/ceremony.py
+++ b/repository_service_tuf/cli/admin/ceremony.py
@@ -660,9 +660,9 @@ def ceremony(
 
     # option bootstrap: checks if the server accepts it beforehand
     if bootstrap:
-        if settings.AUTH is True and upload_server is None:
+        if settings.AUTH is False and upload_server is None:
             raise click.ClickException(
-                "Requires '--upload-server' when using '--auth'. "
+                "Requires '--upload-server' "
                 "Example: --upload-server https://rstuf-api.example.com"
             )
         elif upload_server:

--- a/repository_service_tuf/cli/admin/token.py
+++ b/repository_service_tuf/cli/admin/token.py
@@ -54,7 +54,9 @@ def generate(context, scope, expires):
     logged_token = settings.get("TOKEN")
     login = is_logged(settings)
     if login.state is False:
-        raise click.ClickException("Not logged. Use 'rstuf admin login'")
+        raise click.ClickException(
+            "Not logged. Use 'rstuf --auth admin login'"
+        )
 
     headers = {"Authorization": f"Bearer {logged_token}"}
     payload = {"scopes": list(scope), "expires": expires}
@@ -88,7 +90,9 @@ def inspect(context, token):
     logged_token = settings.get("TOKEN")
     login = is_logged(settings)
     if login.state is False:
-        raise click.ClickException("Not logged. Use 'rstuf admin login'")
+        raise click.ClickException(
+            "Not logged. Use 'rstuf --auth admin login'"
+        )
 
     headers = {"Authorization": f"Bearer {logged_token}"}
     response = request_server(

--- a/repository_service_tuf/helpers/api_client.py
+++ b/repository_service_tuf/helpers/api_client.py
@@ -99,13 +99,13 @@ def get_headers(settings: LazySettings) -> Dict[str, str]:
         if token_access_check.state is False:
             raise click.ClickException(
                 f"{str(token_access_check.data)}"
-                "\n\nTry re-login: 'rstuf admin login'"
+                "\n\nTry re-login: 'rstuf --auth admin login'"
             )
 
         expired_admin = token_access_check.data.get("expired")
         if expired_admin is True:
             raise click.ClickException(
-                "The token has expired. Run 'rstuf admin login'"
+                "The token has expired. Run 'rstuf --auth admin login'"
             )
         else:
             headers = {"Authorization": f"Bearer {token}"}
@@ -117,7 +117,9 @@ def get_headers(settings: LazySettings) -> Dict[str, str]:
                     f"Unexpected error: {response.text}"
                 )
     else:
-        raise click.ClickException("Login first. Run 'rstuf admin login'")
+        raise click.ClickException(
+            "Login first. Run 'rstuf --auth admin login'"
+        )
 
     return headers
 

--- a/tests/unit/helpers/test_api_client.py
+++ b/tests/unit/helpers/test_api_client.py
@@ -190,7 +190,7 @@ class TestAPIClient:
         with pytest.raises(api_client.click.ClickException) as err:
             api_client.get_headers({})
 
-        assert "Login first. Run 'rstuf admin login'" in str(err)
+        assert "Login first. Run 'rstuf --auth admin login'" in str(err)
 
     def test_get_headers_is_logged_state_false(self, test_context):
         api_client.is_logged = pretend.call_recorder(


### PR DESCRIPTION
The RSTUF CLI was with incorrect behavior during the bootstrap process.

When the user was using `--auth` it was still requiring the `--upload-server` parameter, even after the login procedure `rstuf --auth admin login`

Also, when using the CLI without the authn/z, it was not asking the user the required `--upload-server` parameter.

This commit fixes the correct behavior

```
❯ rstuf --auth admin login
❯ rstuf --auth admin ceremony -b -u

❯ rstuf admin ceremony -b -u
╭─ Error ────────────────────────────────────────────────────────────────────────────╮
│ Requires '--upload-server' Example: --upload-server https://rstuf-api.example.com  │
╰────────────────────────────────────────────────────────────────────────────────────╯
❯ rstuf admin ceremony -b -u --upload-server http://127.0.0.1
```

Part of #307
Closes #312