### PR TITLE
Add metadata-update-payload.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,7 @@ dmypy.json
 .pyre/
 
 payload.json
+metadata-update-payload.json
 
 # VScode settings folder
 .vscode


### PR DESCRIPTION
Add `metadata-update-payload.json` to `.gitignore` to not generate new files during github workflows