### PR TITLE
Update python tuf version to 3.0.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,7 @@ click = "*"
 rich = "*"
 PyNaCl = "==1.5.0"
 requests = "*"
-tuf = "==2.0.0"
+tuf = "==3.0.0"
 dynaconf = {extras = ["ini"], version = "*"}
 isort = "*"
 sqlalchemy = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "cfa21df3cb514741120ccf93fa49e9082cb5dfa093cc161b508130e0418a0c32"
+            "sha256": "e3d56e6b0cd1b2a054739e6ebfd3145f0b23eb506231957f28e5104d51e3ce47"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,11 +18,11 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7",
-                "sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716"
+                "sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082",
+                "sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2023.5.7"
+            "version": "==2023.7.22"
         },
         "cffi": {
             "hashes": [
@@ -176,11 +176,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:4be4b1af8d665c6d942909916d31a213a106800c47d0eeba73d34da3cbc11367",
-                "sha256:e576aa487d679441d7d30abb87e1b43d24fc53bffb8758443b1a9e1cee504548"
+                "sha256:48ee849951919527a045bfe3bf7baa8a959c423134e1a5b98c05c20ba75a1cbd",
+                "sha256:fa244bb30b3b5ee2cae3da8f55c9e5e0c0e86093306301fb418eb9dc40fbded5"
             ],
             "index": "pypi",
-            "version": "==8.1.5"
+            "version": "==8.1.6"
         },
         "configobj": {
             "hashes": [
@@ -387,11 +387,11 @@
         },
         "rich": {
             "hashes": [
-                "sha256:8f87bc7ee54675732fa66a05ebfe489e27264caeeff3728c945d25971b6485ec",
-                "sha256:d653d6bccede5844304c605d5aac802c7cf9621efd700b46c7ec2b51ea914898"
+                "sha256:881653ee7037803559d8eae98f145e0a4c4b0ec3ff0300d2cc8d479c71fc6819",
+                "sha256:b97381b204a206e1be618f5e1215a57174a1a7732490b3bf6668cf41d30bc72d"
             ],
             "index": "pypi",
-            "version": "==13.4.2"
+            "version": "==13.5.1"
         },
         "rich-click": {
             "hashes": [
@@ -469,11 +469,11 @@
         },
         "tuf": {
             "hashes": [
-                "sha256:1524b0fbd8504245f600f121daf86b8fdcb30df74410acc9655944c4868e461c",
-                "sha256:76e7f2a7aced84466865fac2a7127b6085afae51d4328af896fb46f952dd3a53"
+                "sha256:493f5e9dc60c6a216320a82e052f6bd6f4b12cf8dfafc90ce6de537545ccfa61",
+                "sha256:e8fb94cb38f472530d591c59e87f22698355a673231f5bf50d7d1da4842c0007"
             ],
             "index": "pypi",
-            "version": "==2.0.0"
+            "version": "==3.0.0"
         },
         "typing-extensions": {
             "hashes": [
@@ -485,11 +485,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:48e7fafa40319d358848e1bc6809b208340fafe2096f1725d05d67443d0483d1",
-                "sha256:bee28b5e56addb8226c96f7f13ac28cb4c301dd5ea8a6ca179c0b9835e032825"
+                "sha256:8d22f86aae8ef5e410d4f539fde9ce6b2113a001bb4d189e0aed70642d602b11",
+                "sha256:de7df1803967d2c2a98e4b11bb7d6bd9210474c46e8a0401514e3a42a75ebde4"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.0.3"
+            "version": "==2.0.4"
         }
     },
     "develop": {
@@ -563,11 +563,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7",
-                "sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716"
+                "sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082",
+                "sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2023.5.7"
+            "version": "==2023.7.22"
         },
         "cfgv": {
             "hashes": [
@@ -668,11 +668,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:4be4b1af8d665c6d942909916d31a213a106800c47d0eeba73d34da3cbc11367",
-                "sha256:e576aa487d679441d7d30abb87e1b43d24fc53bffb8758443b1a9e1cee504548"
+                "sha256:48ee849951919527a045bfe3bf7baa8a959c423134e1a5b98c05c20ba75a1cbd",
+                "sha256:fa244bb30b3b5ee2cae3da8f55c9e5e0c0e86093306301fb418eb9dc40fbded5"
             ],
             "index": "pypi",
-            "version": "==8.1.5"
+            "version": "==8.1.6"
         },
         "colorama": {
             "hashes": [
@@ -750,10 +750,10 @@
         },
         "distlib": {
             "hashes": [
-                "sha256:14bad2d9b04d3a36127ac97f30b12a19268f211063d8f8ee4f47108896e11b46",
-                "sha256:f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e"
+                "sha256:2e24928bc811348f0feb63014e97aaae3037f2cf48712d51ae61df7fd6075057",
+                "sha256:9dafe54b34a028eafd95039d5e5d4851a13734540f1331060d31c9916e7147a8"
             ],
-            "version": "==0.3.6"
+            "version": "==0.3.7"
         },
         "docutils": {
             "hashes": [
@@ -765,11 +765,11 @@
         },
         "editables": {
             "hashes": [
-                "sha256:dc322c42e7ccaf19600874035a4573898d88aadd07e177c239298135b75da772",
-                "sha256:dd430dcf41c78d1d68ebbb893e498b0a306b554be9e7cede73b1c876c6ddbc8d"
+                "sha256:309627d9b5c4adc0e668d8c6fa7bac1ba7c8c5d415c2d27f60f081f8e80d1de2",
+                "sha256:61e5ffa82629e0d8bfe09bc44a07db3c1ab8ed1ce78a6980732870f19b5e7d4c"
             ],
             "markers": "python_version >= '3.1'",
-            "version": "==0.4"
+            "version": "==0.5"
         },
         "exceptiongroup": {
             "hashes": [
@@ -789,11 +789,11 @@
         },
         "flake8": {
             "hashes": [
-                "sha256:3833794e27ff64ea4e9cf5d410082a8b97ff1a06c16aa3d2027339cd0f1195c7",
-                "sha256:c61007e76655af75e6785a931f452915b371dc48f56efd765247c8fe68f2b181"
+                "sha256:d5b3857f07c030bdb5bf41c7f53799571d75c4491748a3adcd47de929e34cd23",
+                "sha256:ffdfce58ea94c6580c77888a86506937f9a1a227dfcd15f245d694ae20a6b6e5"
             ],
             "index": "pypi",
-            "version": "==6.0.0"
+            "version": "==6.1.0"
         },
         "gitdb": {
             "hashes": [
@@ -821,11 +821,11 @@
         },
         "identify": {
             "hashes": [
-                "sha256:0aac67d5b4812498056d28a9a512a483f5085cc28640b02b258a59dac34301d4",
-                "sha256:986dbfb38b1140e763e413e6feb44cd731faf72d1909543178aa79b0e258265d"
+                "sha256:7243800bce2f58404ed41b7c002e53d4d22bcf3ae1b7900c2d7aefd95394bf7f",
+                "sha256:c22a8ead0d4ca11f1edd6c9418c3220669b3b7533ada0a0ffa6cc0ef85cf9b54"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.5.24"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.5.26"
         },
         "idna": {
             "hashes": [
@@ -1013,11 +1013,11 @@
         },
         "pathspec": {
             "hashes": [
-                "sha256:2798de800fa92780e33acca925945e9a19a133b715067cf165b8866c15a31687",
-                "sha256:d8af70af76652554bd134c22b3e8a1cc46ed7d91edcdd721ef1a0c51a84a5293"
+                "sha256:1d6ed233af05e679efb96b1851550ea95bbb64b7c490b0f5aa52996c11e92a20",
+                "sha256:e0d8d0ac2f12da61956eb2306b69f9469b42f4deb0f3cb6ed47b9cce9996ced3"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.11.1"
+            "version": "==0.11.2"
         },
         "pbr": {
             "hashes": [
@@ -1029,19 +1029,19 @@
         },
         "pip": {
             "hashes": [
-                "sha256:78e5353a9dda374b462f2054f83a7b63f3f065c98236a68361845c1b0ee7e35f",
-                "sha256:a160a170f3331d9ca1a0247eb1cd79c758879f1f81158f9cd05bbb5df80bea5c"
+                "sha256:7ccf472345f20d35bdc9d1841ff5f313260c2c33fe417f48c30ac46cccabf5be",
+                "sha256:fb0bd5435b3200c602b5bf61d2d43c2f13c02e29c1707567ae7fbc514eb9faf2"
             ],
             "index": "pypi",
-            "version": "==23.2"
+            "version": "==23.2.1"
         },
         "platformdirs": {
             "hashes": [
-                "sha256:1b42b450ad933e981d56e59f1b97495428c9bd60698baab9f3eb3d00d5822421",
-                "sha256:ad8291ae0ae5072f66c16945166cb11c63394c7a3ad1b1bc9828ca3162da8c2f"
+                "sha256:b45696dab2d7cc691a3226759c0d3b00c47c8b6e293d96f6436f733303f77f6d",
+                "sha256:d7c24979f292f916dc9cbf8648319032f551ea8c49a4c9bf2fb556a02070ec1d"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.9.1"
+            "version": "==3.10.0"
         },
         "pluggy": {
             "hashes": [
@@ -1069,19 +1069,19 @@
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:347187bdb476329d98f695c213d7295a846d1152ff4fe9bacb8a9590b8ee7053",
-                "sha256:8a4eaf0d0495c7395bdab3589ac2db602797d76207242c17d470186815706610"
+                "sha256:259bcc17857d8a8b3b4a2327324b79e5f020a13c16074670f9c8c8f872ea76d0",
+                "sha256:5d1013ba8dc7895b548be5afb05740ca82454fd899971563d2ef625d090326f8"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2.10.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.11.0"
         },
         "pyflakes": {
             "hashes": [
-                "sha256:ec55bf7fe21fff7f1ad2f7da62363d749e2a470500eab1b555334b67aa1ef8cf",
-                "sha256:ec8b276a6b60bd80defed25add7e439881c19e64850afd9b346283d4165fd0fd"
+                "sha256:4132f6d49cb4dae6819e5379898f2b8cce3c5f23994194c24b77d5da2e36f774",
+                "sha256:a0aae034c444db0071aa077972ba4768d40c830d9539fd45bf4cd3f8f6992efc"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.0.1"
+            "markers": "python_version >= '3.8'",
+            "version": "==3.1.0"
         },
         "pygments": {
             "hashes": [
@@ -1117,49 +1117,49 @@
         },
         "pyyaml": {
             "hashes": [
-                "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf",
-                "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293",
-                "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b",
-                "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57",
-                "sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b",
-                "sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4",
-                "sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07",
-                "sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba",
-                "sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9",
-                "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287",
-                "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513",
-                "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0",
-                "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782",
-                "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0",
-                "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92",
-                "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f",
-                "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2",
-                "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc",
-                "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1",
-                "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c",
-                "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86",
-                "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4",
-                "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c",
-                "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34",
-                "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b",
-                "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d",
-                "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c",
-                "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb",
-                "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7",
-                "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737",
-                "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3",
-                "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d",
-                "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358",
-                "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53",
-                "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78",
-                "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803",
-                "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a",
-                "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f",
-                "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174",
-                "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"
+                "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc",
+                "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741",
+                "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206",
+                "sha256:18aeb1bf9a78867dc38b259769503436b7c72f7a1f1f4c93ff9a17de54319b27",
+                "sha256:1d4c7e777c441b20e32f52bd377e0c409713e8bb1386e1099c2415f26e479595",
+                "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62",
+                "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98",
+                "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696",
+                "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d",
+                "sha256:4fb147e7a67ef577a588a0e2c17b6db51dda102c71de36f8549b6816a96e1867",
+                "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47",
+                "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486",
+                "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6",
+                "sha256:596106435fa6ad000c2991a98fa58eeb8656ef2325d7e158344fb33864ed87e3",
+                "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007",
+                "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938",
+                "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c",
+                "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735",
+                "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d",
+                "sha256:9046c58c4395dff28dd494285c82ba00b546adfc7ef001486fbf0324bc174fba",
+                "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8",
+                "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5",
+                "sha256:afd7e57eddb1a54f0f1a974bc4391af8bcce0b444685d936840f125cf046d5bd",
+                "sha256:b1275ad35a5d18c62a7220633c913e1b42d44b46ee12554e5fd39c70a243d6a3",
+                "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0",
+                "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515",
+                "sha256:baa90d3f661d43131ca170712d903e6295d1f7a0f595074f151c0aed377c9b9c",
+                "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c",
+                "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924",
+                "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34",
+                "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43",
+                "sha256:c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859",
+                "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673",
+                "sha256:d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a",
+                "sha256:f003ed9ad21d6a4713f0a9b5a7a0a79e08dd0f221aff4525a2be4c346ee60aab",
+                "sha256:f22ac1c3cac4dbc50079e965eba2c1058622631e526bd9afd45fedd49ba781fa",
+                "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c",
+                "sha256:fca0e3a251908a499833aa292323f32437106001d436eca0e6e7833256674585",
+                "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d",
+                "sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==6.0"
+            "version": "==6.0.1"
         },
         "requests": {
             "hashes": [
@@ -1171,11 +1171,11 @@
         },
         "rich": {
             "hashes": [
-                "sha256:8f87bc7ee54675732fa66a05ebfe489e27264caeeff3728c945d25971b6485ec",
-                "sha256:d653d6bccede5844304c605d5aac802c7cf9621efd700b46c7ec2b51ea914898"
+                "sha256:881653ee7037803559d8eae98f145e0a4c4b0ec3ff0300d2cc8d479c71fc6819",
+                "sha256:b97381b204a206e1be618f5e1215a57174a1a7732490b3bf6668cf41d30bc72d"
             ],
             "index": "pypi",
-            "version": "==13.4.2"
+            "version": "==13.5.1"
         },
         "setuptools": {
             "hashes": [
@@ -1305,18 +1305,18 @@
         },
         "types-requests": {
             "hashes": [
-                "sha256:3de667cffa123ce698591de0ad7db034a5317457a596eb0b4944e5a9d9e8d1ac",
-                "sha256:afb06ef8f25ba83d59a1d424bd7a5a939082f94b94e90ab5e6116bd2559deaa3"
+                "sha256:56d181c85b5925cbc59f4489a57e72a8b2166f18273fd8ba7b6fe0c0b986f12a",
+                "sha256:6aa3f7faf0ea52d728bb18c0a0d1522d9bfd8c72d26ff6f61bfc3d06a411cf40"
             ],
             "index": "pypi",
-            "version": "==2.31.0.1"
+            "version": "==2.31.0.2"
         },
         "types-urllib3": {
             "hashes": [
-                "sha256:3300538c9dc11dad32eae4827ac313f5d986b8b21494801f1bf97a1ac6c03ae5",
-                "sha256:5dbd1d2bef14efee43f5318b5d36d805a489f6600252bb53626d4bfafd95e27c"
+                "sha256:229b7f577c951b8c1b92c1bc2b2fdb0b49847bd2af6d1cc2a2e3dd340f3bda8f",
+                "sha256:9683bbb7fb72e32bfe9d2be6e04875fbe1b3eeec3cbb4ea231435aa7fd6b4f0e"
             ],
-            "version": "==1.26.25.13"
+            "version": "==1.26.25.14"
         },
         "typing-extensions": {
             "hashes": [
@@ -1328,19 +1328,19 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:48e7fafa40319d358848e1bc6809b208340fafe2096f1725d05d67443d0483d1",
-                "sha256:bee28b5e56addb8226c96f7f13ac28cb4c301dd5ea8a6ca179c0b9835e032825"
+                "sha256:8d22f86aae8ef5e410d4f539fde9ce6b2113a001bb4d189e0aed70642d602b11",
+                "sha256:de7df1803967d2c2a98e4b11bb7d6bd9210474c46e8a0401514e3a42a75ebde4"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.0.3"
+            "version": "==2.0.4"
         },
         "virtualenv": {
             "hashes": [
-                "sha256:18d1b37fc75cc2670625702d76849a91ebd383768b4e91382a8d51be3246049e",
-                "sha256:e2a7cef9da880d693b933db7654367754f14e20650dc60e8ee7385571f8593a3"
+                "sha256:43a3052be36080548bdee0b42919c88072037d50d56c28bd3f853cbe92b953ff",
+                "sha256:fd8a78f46f6b99a67b7ec5cf73f92357891a7b3a40fd97637c27f854aae3b9e0"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==20.24.0"
+            "version": "==20.24.2"
         },
         "zipp": {
             "hashes": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "rich",
   "rich-click",
   "securesystemslib[crypto]",
-  "tuf==2.0.0",
+  "tuf==3.0.0",
 ]
 dynamic = ["version"]
 

--- a/repository_service_tuf/helpers/tuf.py
+++ b/repository_service_tuf/helpers/tuf.py
@@ -20,9 +20,11 @@ from securesystemslib.exceptions import (  # type: ignore
 from securesystemslib.interface import (  # type: ignore
     import_privatekey_from_file,
 )
-from securesystemslib.signer import Signer, SSlibSigner  # type: ignore
+from securesystemslib.signer import Signer  # type: ignore
+from securesystemslib.signer import SSlibSigner  # type: ignore
+from securesystemslib.signer import SSlibKey as Key  # type: ignore
 from tuf.api.exceptions import UnsignedMetadataError
-from tuf.api.metadata import SPECIFICATION_VERSION, Key, Metadata, Role, Root
+from tuf.api.metadata import SPECIFICATION_VERSION, Metadata, Role, Root
 from tuf.api.serialization.json import JSONSerializer
 
 console = Console()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,89 +1,89 @@
 -i https://pypi.org/simple
-alabaster==0.7.13; python_version >= '3.6'
-babel==2.12.1; python_version >= '3.7'
+alabaster==0.7.13 ; python_version >= '3.6'
+babel==2.12.1 ; python_version >= '3.7'
 bandit==1.7.5
 black==23.7.0
 build==0.10.0
-cachetools==5.3.1; python_version >= '3.7'
-certifi==2023.5.7; python_version >= '3.6'
-cfgv==3.3.1; python_full_version >= '3.6.1'
-chardet==5.1.0; python_version >= '3.7'
-charset-normalizer==3.2.0; python_full_version >= '3.7.0'
-click==8.1.5
-colorama==0.4.6; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
+cachetools==5.3.1 ; python_version >= '3.7'
+certifi==2023.7.22 ; python_version >= '3.6'
+cfgv==3.3.1 ; python_full_version >= '3.6.1'
+chardet==5.1.0 ; python_version >= '3.7'
+charset-normalizer==3.2.0 ; python_full_version >= '3.7.0'
+click==8.1.6
+colorama==0.4.6 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
 coverage==7.2.7
-distlib==0.3.6
-docutils==0.18.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-editables==0.4; python_version >= '3.1'
-exceptiongroup==1.1.2; python_version < '3.11'
-filelock==3.12.2; python_version >= '3.7'
-flake8==6.0.0
-gitdb==4.0.10; python_version >= '3.7'
-gitpython==3.1.32; python_version >= '3.7'
+distlib==0.3.7
+docutils==0.18.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+editables==0.5 ; python_version >= '3.1'
+exceptiongroup==1.1.2 ; python_version < '3.11'
+filelock==3.12.2 ; python_version >= '3.7'
+flake8==6.1.0
+gitdb==4.0.10 ; python_version >= '3.7'
+gitpython==3.1.32 ; python_version >= '3.7'
 hatchling==0.22.0
-identify==2.5.24; python_version >= '3.7'
-idna==3.4; python_version >= '3.5'
-imagesize==1.4.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-importlib-metadata==6.8.0; python_version < '3.10'
-iniconfig==2.0.0; python_version >= '3.7'
+identify==2.5.26 ; python_version >= '3.8'
+idna==3.4 ; python_version >= '3.5'
+imagesize==1.4.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+importlib-metadata==6.8.0 ; python_version < '3.10'
+iniconfig==2.0.0 ; python_version >= '3.7'
 isort==5.12.0
-jinja2==3.1.2; python_version >= '3.7'
-markdown-it-py==3.0.0; python_version >= '3.8'
-markupsafe==2.1.3; python_version >= '3.7'
-mccabe==0.7.0; python_version >= '3.6'
-mdurl==0.1.2; python_version >= '3.7'
+jinja2==3.1.2 ; python_version >= '3.7'
+markdown-it-py==3.0.0 ; python_version >= '3.8'
+markupsafe==2.1.3 ; python_version >= '3.7'
+mccabe==0.7.0 ; python_version >= '3.6'
+mdurl==0.1.2 ; python_version >= '3.7'
 mypy==1.4.1
-mypy-extensions==1.0.0; python_version >= '3.5'
-nodeenv==1.8.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
-packaging==23.1; python_version >= '3.1'
-pathspec==0.11.1; python_version >= '3.7'
-pbr==5.11.1; python_version >= '2.6'
-pip==23.2
-platformdirs==3.9.1; python_version >= '3.7'
-pluggy==1.2.0; python_version >= '3.1'
+mypy-extensions==1.0.0 ; python_version >= '3.5'
+nodeenv==1.8.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
+packaging==23.1 ; python_version >= '3.1'
+pathspec==0.11.2 ; python_version >= '3.7'
+pbr==5.11.1 ; python_version >= '2.6'
+pip==23.2.1
+platformdirs==3.10.0 ; python_version >= '3.7'
+pluggy==1.2.0 ; python_version >= '3.1'
 pre-commit==3.3.3
 pretend==1.0.9
-pycodestyle==2.10.0; python_version >= '3.6'
-pyflakes==3.0.1; python_version >= '3.6'
-pygments==2.15.1; python_version >= '3.7'
-pyproject-api==1.5.3; python_version >= '3.7'
-pyproject-hooks==1.0.0; python_version >= '3.7'
+pycodestyle==2.11.0 ; python_version >= '3.8'
+pyflakes==3.1.0 ; python_version >= '3.8'
+pygments==2.15.1 ; python_version >= '3.7'
+pyproject-api==1.5.3 ; python_version >= '3.7'
+pyproject-hooks==1.0.0 ; python_version >= '3.7'
 pytest==7.4.0
-pyyaml==6.0; python_version >= '3.6'
+pyyaml==6.0.1 ; python_version >= '3.6'
 requests==2.31.0
-rich==13.4.2
-setuptools==68.0.0; python_version >= '3.7'
-smmap==5.0.0; python_version >= '3.6'
+rich==13.5.1
+setuptools==68.0.0 ; python_version >= '3.7'
+smmap==5.0.0 ; python_version >= '3.6'
 snowballstemmer==2.2.0
 sphinx==6.2.1
 sphinx-rtd-theme==1.2.2
 sphinxcontrib-applehelp==1.0.4
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.1
-sphinxcontrib-jquery==4.1; python_version >= '2.7'
+sphinxcontrib-jquery==4.1 ; python_version >= '2.7'
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-plantuml==0.25
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
-stevedore==5.1.0; python_version >= '3.8'
-tomli==2.0.1; python_version >= '3.1'
+stevedore==5.1.0 ; python_version >= '3.8'
+tomli==2.0.1 ; python_version >= '3.1'
 tox==4.6.4
-types-requests==2.31.0.1
-types-urllib3==1.26.25.13
-typing-extensions==4.7.1; python_version >= '3.7'
-urllib3==2.0.3; python_version >= '3.7'
-virtualenv==20.24.0; python_version >= '3.7'
-zipp==3.16.2; python_version >= '3.8'
+types-requests==2.31.0.2
+types-urllib3==1.26.25.14
+typing-extensions==4.7.1 ; python_version >= '3.7'
+urllib3==2.0.4 ; python_version >= '3.7'
+virtualenv==20.24.2 ; python_version >= '3.7'
+zipp==3.16.2 ; python_version >= '3.8'
 cffi==1.15.1
 configobj==5.0.8
 cryptography==41.0.2
 dynaconf[ini]==3.2.0
-greenlet==2.0.2; platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))
+greenlet==2.0.2 ; platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))
 psycopg2==2.9.6
 pycparser==2.21
 pynacl==1.5.0
 rich-click==1.6.1
 securesystemslib[crypto]==0.28.0
-six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 sqlalchemy==2.0.19
-tuf==2.0.0
+tuf==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,26 +1,26 @@
 -i https://pypi.org/simple
-certifi==2023.5.7; python_version >= '3.6'
+certifi==2023.7.22 ; python_version >= '3.6'
 cffi==1.15.1
-charset-normalizer==3.2.0; python_full_version >= '3.7.0'
-click==8.1.5
+charset-normalizer==3.2.0 ; python_full_version >= '3.7.0'
+click==8.1.6
 configobj==5.0.8
 cryptography==41.0.2
 dynaconf[ini]==3.2.0
-greenlet==2.0.2; platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))
-idna==3.4; python_version >= '3.5'
+greenlet==2.0.2 ; platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))
+idna==3.4 ; python_version >= '3.5'
 isort==5.12.0
-markdown-it-py==3.0.0; python_version >= '3.8'
-mdurl==0.1.2; python_version >= '3.7'
+markdown-it-py==3.0.0 ; python_version >= '3.8'
+mdurl==0.1.2 ; python_version >= '3.7'
 psycopg2==2.9.6
 pycparser==2.21
-pygments==2.15.1; python_version >= '3.7'
+pygments==2.15.1 ; python_version >= '3.7'
 pynacl==1.5.0
 requests==2.31.0
-rich==13.4.2
+rich==13.5.1
 rich-click==1.6.1
 securesystemslib[crypto]==0.28.0
-six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 sqlalchemy==2.0.19
-tuf==2.0.0
-typing-extensions==4.7.1; python_version >= '3.7'
-urllib3==2.0.3; python_version >= '3.7'
+tuf==3.0.0
+typing-extensions==4.7.1 ; python_version >= '3.7'
+urllib3==2.0.4 ; python_version >= '3.7'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,8 @@ from typing import Any, Dict, List, Tuple
 import pytest  # type: ignore
 from click.testing import CliRunner  # type: ignore
 from dynaconf import Dynaconf
-from tuf.api.metadata import Key, Metadata, Root
+from securesystemslib.signer import SSlibKey as Key
+from tuf.api.metadata import Metadata, Root
 
 from repository_service_tuf.helpers.tuf import (
     BootstrapSetup,

--- a/tests/unit/helpers/test_tuf.py
+++ b/tests/unit/helpers/test_tuf.py
@@ -9,12 +9,12 @@ from typing import Dict, List
 
 import pretend
 import pytest
+from securesystemslib.signer import SSlibKey as Key  # type: ignore
 from tuf.api.exceptions import UnsignedMetadataError
 
 from repository_service_tuf.constants import KeyType
 from repository_service_tuf.helpers import tuf
 from repository_service_tuf.helpers.tuf import (
-    Key,
     Metadata,
     Roles,
     Root,


### PR DESCRIPTION
- Updated `python-tuf` to version 3.0.0 
- Updated all requirements
- Based on https://github.com/theupdateframework/python-tuf/blob/v3.0.0/docs/CHANGELOG.md, the change that would
break `rstuf` is `Key.from_securesystemslib_key()` being removed.
Thus, it was replaced in the code with Securesystemslibs `SSlibKey.from_securesystemslib_key()` as suggested.
- Adjusted tests

Closes #327