### PR TITLE
Add `--token` option for `rstuf` commands

### DIFF
--- a/repository_service_tuf/cli/__init__.py
+++ b/repository_service_tuf/cli/__init__.py
@@ -8,10 +8,12 @@ import pkgutil
 import re
 import sys
 from pathlib import Path
+from typing import Optional
 
 import rich_click as click  # type: ignore
 from auto_click_auto import enable_click_shell_completion
 from auto_click_auto.constants import ShellType
+from click import Context
 from rich.console import Console
 from rich.panel import Panel
 
@@ -55,17 +57,32 @@ except FileNotFoundError:
     default=False,
     required=False,
 )
+@click.option(
+    "-t",
+    "--token",
+    help=(
+        "RSTUF API authentication token. If the `--auth` option is provided"
+        "this token is not used for authentication."
+    ),
+    required=False,
+    default=None,
+)
 # adds the --version parameter
 @click.version_option(prog_name=prog_name, version=version)
 @click.pass_context
-def rstuf(context, config, auth):
-    """
-    Repository Service for TUF Command Line Interface (CLI).
-    """
+def rstuf(
+    context: Context,
+    config: Optional[str],
+    auth: Optional[str],
+    token: Optional[str],
+):
+    """Repository Service for TUF Command Line Interface (CLI)."""
+
     context.obj = {
         "settings": Dynaconf(settings_files=[config]),
         "config": config,
         "auth": auth,
+        "token": token,
     }
     settings = context.obj["settings"]
     if auth is True:

--- a/repository_service_tuf/cli/admin/ceremony.py
+++ b/repository_service_tuf/cli/admin/ceremony.py
@@ -682,6 +682,7 @@ def ceremony(
             payload=bootstrap_payload,
             expected_msg="Bootstrap accepted.",
             command_name="Bootstrap",
+            token=context.obj.get("token"),
         )
         task_status(task_id, settings, "Bootstrap status: ")
         console.print(f"Bootstrap completed using `{file}`. 🔐 🎉")
@@ -701,6 +702,7 @@ def ceremony(
                 payload=bootstrap_payload,
                 expected_msg="Bootstrap accepted.",
                 command_name="Bootstrap",
+                token=context.obj.get("token"),
             )
             task_status(task_id, settings, "Bootstrap status: ")
             console.print("\nCeremony done. 🔐 🎉. Bootstrap completed.")

--- a/repository_service_tuf/cli/admin/metadata.py
+++ b/repository_service_tuf/cli/admin/metadata.py
@@ -519,6 +519,7 @@ def update(
             payload=payload,
             expected_msg="Metadata update accepted.",
             command_name="Metadata Update",
+            token=context.obj.get("token"),
         )
         task_status(task_id, settings, "Metadata Update status: ")
         console.print(f"Existing payload {file} sent")
@@ -579,6 +580,7 @@ def update(
                 payload=payload,
                 expected_msg="Metadata update accepted.",
                 command_name="Metadata Update",
+                token=context.obj.get("token"),
             )
             task_status(task_id, settings, "Metadata Update status: ")
 

--- a/tests/unit/cli/admin/test_ceremony.py
+++ b/tests/unit/cli/admin/test_ceremony.py
@@ -443,6 +443,7 @@ class TestCeremonyOptions:
                 payload={"k": "v"},
                 expected_msg="Bootstrap accepted.",
                 command_name="Bootstrap",
+                token=test_context.get("token"),
             )
         ]
         assert ceremony._run_ceremony_steps.calls == [pretend.call(False)]
@@ -516,6 +517,7 @@ class TestCeremonyOptions:
                 payload={"k": "v"},
                 expected_msg="Bootstrap accepted.",
                 command_name="Bootstrap",
+                token=test_context.get("token"),
             )
         ]
         assert ceremony.task_status.calls == [
@@ -575,6 +577,7 @@ class TestCeremonyOptions:
                 payload={"k": "v"},
                 expected_msg="Bootstrap accepted.",
                 command_name="Bootstrap",
+                token=test_context.get("token"),
             )
         ]
         assert ceremony.task_status.calls == [

--- a/tests/unit/cli/admin/test_metadata_update.py
+++ b/tests/unit/cli/admin/test_metadata_update.py
@@ -593,6 +593,7 @@ class TestMetadataUpdateOptions:
                 payload={"data": "а"},
                 expected_msg="Metadata update accepted.",
                 command_name="Metadata Update",
+                token=test_context.get("token"),
             )
         ]
         assert metadata.task_status.calls == [
@@ -681,6 +682,7 @@ class TestMetadataUpdateOptions:
                 payload={"data": "foo"},
                 expected_msg="Metadata update accepted.",
                 command_name="Metadata Update",
+                token=test_context.get("token"),
             )
         ]
         assert metadata.task_status.calls == [

--- a/tests/unit/helpers/test_api_client.py
+++ b/tests/unit/helpers/test_api_client.py
@@ -170,7 +170,9 @@ class TestAPIClient:
 
         assert result == {"Authorization": "Bearer fake_token"}
         assert api_client.is_logged.calls == [
-            pretend.call(test_context["settings"])
+            pretend.call(
+                test_context["settings"], test_context["settings"].TOKEN
+            )
         ]
         assert api_client.request_server.calls == [
             pretend.call(
@@ -206,7 +208,9 @@ class TestAPIClient:
 
         assert "re-login" in str(err)
         assert api_client.is_logged.calls == [
-            pretend.call(test_context["settings"])
+            pretend.call(
+                test_context["settings"], test_context["settings"].TOKEN
+            )
         ]
 
     def test_get_headers_is_logged_state_true_expired_token(
@@ -225,7 +229,9 @@ class TestAPIClient:
 
         assert "The token has expired" in str(err)
         assert api_client.is_logged.calls == [
-            pretend.call(test_context["settings"])
+            pretend.call(
+                test_context["settings"], test_context["settings"].TOKEN
+            )
         ]
 
     def test_get_headers_unexpected_error(self, test_context):
@@ -245,7 +251,9 @@ class TestAPIClient:
 
         assert "Unexpected error" in str(err)
         assert api_client.is_logged.calls == [
-            pretend.call(test_context["settings"])
+            pretend.call(
+                test_context["settings"], test_context["settings"].TOKEN
+            )
         ]
 
     def test_bootstrap_status(self, test_context):
@@ -622,7 +630,9 @@ class TestAPIClient:
         )
         assert result == "task_id_123"
         assert api_client.get_headers.calls == [
-            pretend.call(test_context["settings"])
+            pretend.call(
+                test_context["settings"], test_context["settings"].get("TOKEN")
+            )
         ]
         assert api_client.request_server.calls == [
             pretend.call(
@@ -663,7 +673,9 @@ class TestAPIClient:
 
         assert "Error 200" in str(err)
         assert api_client.get_headers.calls == [
-            pretend.call(test_context["settings"])
+            pretend.call(
+                test_context["settings"], test_context["settings"].get("TOKEN")
+            )
         ]
         assert api_client.request_server.calls == [
             pretend.call(
@@ -703,7 +715,9 @@ class TestAPIClient:
 
         assert "No message available." in str(err)
         assert api_client.get_headers.calls == [
-            pretend.call(test_context["settings"])
+            pretend.call(
+                test_context["settings"], test_context["settings"].get("TOKEN")
+            )
         ]
         assert api_client.request_server.calls == [
             pretend.call(
@@ -744,7 +758,9 @@ class TestAPIClient:
 
         assert "Failed to get `task id`" in str(err)
         assert api_client.get_headers.calls == [
-            pretend.call(test_context["settings"])
+            pretend.call(
+                test_context["settings"], test_context["settings"].get("TOKEN")
+            )
         ]
         assert api_client.request_server.calls == [
             pretend.call(
@@ -785,7 +801,9 @@ class TestAPIClient:
 
         assert "Failed to get task response data" in str(err)
         assert api_client.get_headers.calls == [
-            pretend.call(test_context["settings"])
+            pretend.call(
+                test_context["settings"], test_context["settings"].get("TOKEN")
+            )
         ]
         assert api_client.request_server.calls == [
             pretend.call(


### PR DESCRIPTION
- This option allows the user to pass an RSTUF API authentication token,
    besides the "admin" one.
    If the `--auth` option is provided this token is not used for
    authentication.
- `rstuf admin metadata` and `rstuf admin ceremony` have been adjusted to accept the `--token` option.
- **Please also test that the `ceremony` and `metadata` commands work as expected with the `--token` option.**