### PR TITLE
Print metadata role for signing and fix api_url arg

### DIFF
--- a/repository_service_tuf/cli/admin/metadata.py
+++ b/repository_service_tuf/cli/admin/metadata.py
@@ -633,6 +633,8 @@ def _get_pending_roles(
     if settings.AUTH is False and api_url is None:
         api_url = prompt.Prompt.ask("\n[cyan]API[/] URL address")
         settings.SERVER = api_url
+    elif settings.AUTH is False and api_url is not None:
+        settings.SERVER = api_url
 
     headers = get_headers(settings)
     response = request_server(

--- a/repository_service_tuf/cli/admin/metadata.py
+++ b/repository_service_tuf/cli/admin/metadata.py
@@ -692,13 +692,14 @@ def _get_signing_key(role_info: MetadataInfo) -> RSTUFKey:
     if current_role_key_name != sign_key_name:
         raise click.ClickException(f"Loaded key is not '{sign_key_name}'")
 
+    rstuf_key.name = current_role_key_name
     return rstuf_key
 
 
 def _sign_metadata(role_info: MetadataInfo, rstuf_key: RSTUFKey) -> Signature:
     signer = role_info.get_signer(rstuf_key)
     try:
-        signature = role_info._new_md.sign(signer)
+        signature = role_info._new_md.sign(signer, append=True)
     except UnsignedMetadataError as err:
         raise click.ClickException("Problem signing the metadata") from err
 

--- a/repository_service_tuf/cli/admin/metadata.py
+++ b/repository_service_tuf/cli/admin/metadata.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT
+import copy
 import sys
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
-from rich import box, markdown, prompt, table
+from rich import align, box, markdown, prompt, table, text
 from securesystemslib.exceptions import StorageError  # type: ignore
 from securesystemslib.signer import Signature  # type: ignore
 from tuf.api.metadata import Metadata, Root
@@ -135,7 +136,7 @@ def metadata(context):
 
 def _create_keys_table(
     keys: List[Dict[str, Any]], offline_keys: bool, is_minimal: bool
-) -> table.Table:
+) -> align.Align:
     """Gets a new keys table."""
     keys_table: table.Table
     if is_minimal:
@@ -164,27 +165,43 @@ def _create_keys_table(
             f'[yellow]{key["keyval"]["public"]}',
         )
 
-    return keys_table
+    return align.Align.center(keys_table, vertical="middle")
 
 
-def _print_root_info(root_info: MetadataInfo):
-    root_table = table.Table()
-    root_table.add_column("Root", justify="left", vertical="middle")
-    root_table.add_column("KEYS", justify="center", vertical="middle")
-    number_of_keys = len(root_info.keys)
+def _print_md_info_helper(
+    table: table.Table, keys: List[Dict[str, Any]], title: str
+):
+    table.add_row(text.Text(f"{title}", style="b cyan", justify="center"))
+    pending_keys_table = _create_keys_table(keys, True, False)
+    table.add_row(pending_keys_table)
 
-    root_keys_table = _create_keys_table(root_info.keys, True, True)
 
-    root_table.add_row(
+def _print_md_info(md_info: MetadataInfo, trusted_md: Optional[bool] = True):
+    md_table = table.Table()
+    md_table.add_column(md_info.type, justify="left", vertical="middle")
+    md_table.add_column("KEYS", justify="center", vertical="middle")
+    md_keys_table = table.Table(box=box.MINIMAL, show_header=False)
+
+    if not trusted_md:
+        # This role is not yet trusted, not all keys were used for signing.
+        used_keys, pending_keys = md_info._get_pending_and_used_keys()
+        _print_md_info_helper(md_keys_table, used_keys, "\nSIGNING KEYS")
+        _print_md_info_helper(md_keys_table, pending_keys, "\nPENDING KEYS")
+    else:
+        keys = md_info.keys
+        md_signing_keys_table = _create_keys_table(keys, True, True)
+        md_keys_table.add_row(md_signing_keys_table)
+
+    md_table.add_row(
         (
-            f"\nNumber of Keys: [yellow]{number_of_keys}[/]"
-            f"\nThreshold: [yellow]{root_info.threshold}[/]"
-            f"\nRoot Expiration: [yellow]{root_info.expiration_str}[/]"
+            f"\nNumber of Keys: [yellow]{len(md_info.keys)}[/]"
+            f"\nThreshold: [yellow]{md_info.threshold}[/]"
+            f"\n{md_info.type} Expiration: [yellow]{md_info.expiration_str}[/]"
         ),
-        root_keys_table,
+        md_keys_table,
     )
 
-    console.print("\n", root_table)
+    console.print("\n", md_table)
     console.print("\n")
 
 
@@ -407,7 +424,7 @@ def _modify_root_keys(root_info: MetadataInfo):
 
         console.print("\nHere is the current content of root:")
 
-        _print_root_info(root_info)
+        _print_md_info(root_info)
 
 
 def _modify_online_key(root_info: MetadataInfo):
@@ -573,7 +590,7 @@ def update(
 
     console.print(markdown.Markdown(CURRENT_ROOT_INFO), width=100)
 
-    _print_root_info(root_info)
+    _print_md_info(root_info)
 
     _current_md_keys_validation(root_info)
 
@@ -702,10 +719,23 @@ def sign(context, api_url: Optional[str]) -> None:
     settings = context.obj["settings"]
 
     pending_roles = _get_pending_roles(settings, api_url)
-    rolename = prompt.Prompt.ask(
-        "\nChoose a metadata to sign", choices=[role for role in pending_roles]
-    )
-    role_info = MetadataInfo(Metadata.from_dict(pending_roles[rolename]))
+    role_info: MetadataInfo
+    rolename: str
+    while True:
+        rolename = prompt.Prompt.ask(
+            "\nChoose a metadata to sign",
+            choices=[role for role in pending_roles],
+        )
+        role_info = MetadataInfo(
+            Metadata.from_dict(copy.deepcopy(pending_roles[rolename]))
+        )
+        _print_md_info(role_info, False)
+        confirmation = prompt.Confirm.ask(
+            f"\nDo you still want to sign {rolename}?"
+        )
+        if confirmation:
+            break
+
     console.print(
         f"Signing [cyan]{rolename}[/] version "
         f"{role_info._new_md.signed.version}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,6 +176,7 @@ def metadata_sign_input() -> List[str]:
     input = [
         "http://127.0.0.1",  # API URL address
         "root",  # Choose a metadata to sign [root]
+        "y",  # Do you still want to sign root? [y]
         "Jimi Hendrix",  # Choose a private key to load [Jimi Hendrix]
         "",  # Choose Jimi Hendrix key type [ed25519/ecdsa/rsa]
         "tests/files/key_storage/JimiHendrix.key",  # Enter the Jimi Hendrix`s private key path  # noqa

--- a/tests/unit/cli/admin/test_metadata.py
+++ b/tests/unit/cli/admin/test_metadata.py
@@ -722,6 +722,8 @@ class TestMetadataSign:
         )
         assert test_result.exit_code == 0, test_result.output
         assert "Metadata Signed! 🔑" in test_result.output
+        assert "SIGNING KEYS" in test_result.output
+        assert "PENDING KEYS" in test_result.output
         assert metadata.request_server.calls == [
             pretend.call(
                 "http://127.0.0.1",
@@ -841,11 +843,77 @@ class TestMetadataSign:
             )
         ]
 
+    def test_metadata_sign_print_role_and_change(self, client, test_context):
+        input_step = [
+            "http://127.0.0.1",  # API URL address
+            "root",  # Choose a metadata to sign [root]
+            "n",  # Do you still want to sign root? [y]
+            "root",  # Choose a metadata to sign [root]
+            "y",  # Do you still want to sign root? [y]
+            "Jimi Hendrix",  # Choose a private key to load [Jimi Hendrix]
+            "",  # Choose Jimi Hendrix key type [ed25519/ecdsa/rsa]
+            "tests/files/key_storage/JimiHendrix.key",  # Enter the Jimi Hendrix`s private key path  # noqa
+            "strongPass",  # Enter the Jimi Hendrix`s private key password
+        ]
+
+        with open("tests/files/das-root.json", "r") as f:
+            das_root = f.read()
+
+        fake_response_data = {"data": {"metadata": json.loads(das_root)}}
+        fake_response = pretend.stub(
+            json=pretend.call_recorder(lambda: fake_response_data),
+            status_code=200,
+        )
+        metadata.request_server = pretend.call_recorder(
+            lambda *a, **kw: fake_response
+        )
+        metadata.send_payload = pretend.call_recorder(lambda *a: "fake-taskid")
+        metadata.task_status = pretend.call_recorder(lambda *a: "OK")
+
+        test_result = client.invoke(
+            metadata.sign,
+            input="\n".join(input_step),
+            obj=test_context,
+            catch_exceptions=False,
+        )
+        assert test_result.exit_code == 0, test_result.output
+        assert "Metadata Signed! 🔑" in test_result.output
+        assert metadata.request_server.calls == [
+            pretend.call(
+                "http://127.0.0.1",
+                "api/v1/metadata/sign/",
+                metadata.Methods.get,
+                headers={},
+            )
+        ]
+        assert metadata.send_payload.calls == [
+            pretend.call(
+                test_context["settings"],
+                URL.metadata_sign.value,
+                {
+                    "role": "root",
+                    "signature": {
+                        "keyid": "800dfb5a1982b82b7893e58035e19f414f553fc08cbb1130cfbae302a7b7fee5",  # noqa
+                        "sig": "0bb8b18a626e24b5dd7cdfb6bf6a26fc79d40b2b3737a92604d484105374f1431cebc76814cedff7179e8d5a1cec54246a7eccd509213ef33bcc12312f4d0f01",  # noqa
+                    },
+                },
+                "Metadata sign accepted.",
+                "Metadata sign",
+            )
+        ]
+        assert metadata.task_status.calls == [
+            pretend.call(
+                "fake-taskid",
+                test_context["settings"],
+                "Metadata sign status:",
+            )
+        ]
+
     def test_metadata_sign_invalid_private_key_and_abort(
         self, client, test_context, metadata_sign_input
     ):
         input_step = metadata_sign_input
-        input_step[4] = "invalid/file"  # Retry to load the key Jimi Hendrix
+        input_step[5] = "invalid/file"  # Retry to load the key Jimi Hendrix
         input_step.append("n")  # In the end abort
 
         with open("tests/files/das-root.json", "r") as f:
@@ -880,7 +948,7 @@ class TestMetadataSign:
         self, client, test_context, metadata_sign_input
     ):
         input_step = metadata_sign_input
-        input_step[4] = "invalid/file"  # Retry to load the key Jimi Hendrix
+        input_step[5] = "invalid/file"  # Retry to load the key Jimi Hendrix
         input_step.append("y")  # Try again
         input_step.append(
             ""
@@ -949,7 +1017,7 @@ class TestMetadataSign:
     ):
         input_step = metadata_sign_input
         input_step[
-            4
+            5
         ] = "tests/files/key_storage/JanisJoplin.key"  # Enter the root`s private key path  # noqa
 
         with open("tests/files/das-root.json", "r") as f:

--- a/tests/unit/cli/admin/test_metadata.py
+++ b/tests/unit/cli/admin/test_metadata.py
@@ -1051,7 +1051,7 @@ class TestMetadataSign:
         ]
 
     def test_metadata_sign_fails_during_signing(
-        self, client, test_context, metadata_sign_input
+        self, client, test_context, metadata_sign_input, monkeypatch
     ):
         input_step = metadata_sign_input
 
@@ -1063,11 +1063,14 @@ class TestMetadataSign:
             json=pretend.call_recorder(lambda: fake_response_data),
             status_code=200,
         )
-        metadata.request_server = pretend.call_recorder(
+        fake_request_server = pretend.call_recorder(
             lambda *a, **kw: fake_response
         )
-        metadata.Metadata.sign = pretend.raiser(
-            metadata.UnsignedMetadataError("Failed to sign")
+        monkeypatch.setattr(metadata, "request_server", fake_request_server)
+        monkeypatch.setattr(
+            metadata.Metadata,
+            "sign",
+            pretend.raiser(metadata.UnsignedMetadataError("Failed to sign")),
         )
 
         test_result = client.invoke(
@@ -1083,5 +1086,73 @@ class TestMetadataSign:
                 "api/v1/metadata/sign/",
                 metadata.Methods.get,
                 headers={},
+            )
+        ]
+
+
+class TestMetadataSignOptions:
+    def test_metadata_sign_api_url_set_no_auth(self, client, test_context):
+        input_step = [
+            "root",  # Choose a metadata to sign [root]
+            "y",  # Do you still want to sign root? [y]
+            "Jimi Hendrix",  # Choose a private key to load [Jimi Hendrix]
+            "",  # Choose Jimi Hendrix key type [ed25519/ecdsa/rsa]
+            "tests/files/key_storage/JimiHendrix.key",  # Enter the Jimi Hendrix`s private key path  # noqa
+            "strongPass",  # Enter the Jimi Hendrix`s private key password
+        ]
+
+        with open("tests/files/das-root.json", "r") as f:
+            das_root = f.read()
+
+        fake_response_data = {"data": {"metadata": json.loads(das_root)}}
+        fake_response = pretend.stub(
+            json=pretend.call_recorder(lambda: fake_response_data),
+            status_code=200,
+        )
+        metadata.request_server = pretend.call_recorder(
+            lambda *a, **kw: fake_response
+        )
+        metadata.send_payload = pretend.call_recorder(lambda *a: "fake-taskid")
+        metadata.task_status = pretend.call_recorder(lambda *a: "OK")
+
+        test_result = client.invoke(
+            metadata.sign,
+            ["--api-url", "http://127.0.0.1"],
+            input="\n".join(input_step),
+            obj=test_context,
+            catch_exceptions=False,
+        )
+        assert test_result.exit_code == 0, test_result.output
+        assert "Metadata Signed! 🔑" in test_result.output
+        assert "SIGNING KEYS" in test_result.output
+        assert "PENDING KEYS" in test_result.output
+        assert metadata.request_server.calls == [
+            pretend.call(
+                "http://127.0.0.1",
+                "api/v1/metadata/sign/",
+                metadata.Methods.get,
+                headers={},
+            )
+        ]
+        assert metadata.send_payload.calls == [
+            pretend.call(
+                test_context["settings"],
+                URL.metadata_sign.value,
+                {
+                    "role": "root",
+                    "signature": {
+                        "keyid": "800dfb5a1982b82b7893e58035e19f414f553fc08cbb1130cfbae302a7b7fee5",  # noqa
+                        "sig": "0bb8b18a626e24b5dd7cdfb6bf6a26fc79d40b2b3737a92604d484105374f1431cebc76814cedff7179e8d5a1cec54246a7eccd509213ef33bcc12312f4d0f01",  # noqa
+                    },
+                },
+                "Metadata sign accepted.",
+                "Metadata sign",
+            )
+        ]
+        assert metadata.task_status.calls == [
+            pretend.call(
+                "fake-taskid",
+                test_context["settings"],
+                "Metadata sign status:",
             )
         ]

--- a/tests/unit/helpers/test_tuf.py
+++ b/tests/unit/helpers/test_tuf.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import copy
+import json
 import unittest.mock
 from datetime import datetime, timedelta
 from typing import Dict, List
@@ -170,6 +171,33 @@ class TestMetadataInfo:
         key = Key("123456789a", "ed25519", "", {"sha256": "abc"}, {"name": ""})
         name = MetadataInfo._get_key_name(key)
         assert name == "1234567"
+
+    def test__get_pending_and_used_keys(self):
+        with open("tests/files/das-root.json", "r") as f:
+            das_root = json.loads(f.read())
+
+        md_info = MetadataInfo(Metadata.from_dict(das_root["root"]))
+        used_keys_info, pending_keys = md_info._get_pending_and_used_keys()
+        assert len(used_keys_info) == 1
+        assert used_keys_info[0] == {
+            "keyid": "1cebe343e35f0213f6136758e6c3a8f8e1f9eeb7e47a07d5cb336462ed31dcb7",  # noqa
+            "name": "Janis Joplin",
+            "keytype": "ed25519",
+            "keyval": {
+                "public": "ad1709b3cb419b99c5cd7427d6411522e5a93aec6767453e91af921a73d22a3c",  # noqa
+            },
+            "scheme": "ed25519",
+        }
+        assert len(pending_keys) == 1
+        assert pending_keys[0] == {
+            "keyid": "800dfb5a1982b82b7893e58035e19f414f553fc08cbb1130cfbae302a7b7fee5",  # noqa
+            "name": "Jimi Hendrix",
+            "keytype": "ed25519",
+            "keyval": {
+                "public": "7098f769f6ab8502b50f3b58686b8a042d5d3bb75d8b3a48a2fcbc15a0223501",  # noqa
+            },
+            "scheme": "ed25519",
+        }
 
     def test_is_keyid_used_true(self, root: Metadata[Root]):
         root.signed.add_key(Key("id", "ed25519", "", {"sha256": "ab"}), "root")


### PR DESCRIPTION
<!--- Thanks for taking the time to fill out this pull request! -->
<!--- Please fill in the fields below to submit a pull request. 
The more information provided, the better. -->


# Description
<!--- What is the PR about? -->
The current implementation of rstuf admin metadata sign asks to choose the Role to sign, select the key available to sign, and sign it.
The user doesn't have a metadata role overview. It would be interesting to show the following:

- Number of keys
- Threshold
- Current signatures and keys
- Show pending signatures

<!--- Please reference the issue(s) this PR fixes. -->
Fixes #349


# Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct