### PR TITLE
Add delete option for metadata sign

### DIFF
--- a/repository_service_tuf/helpers/api_client.py
+++ b/repository_service_tuf/helpers/api_client.py
@@ -30,6 +30,7 @@ class URL(Enum):
 class Methods(Enum):
     get = "get"
     post = "post"
+    delete = "delete"
 
 
 @dataclass
@@ -58,6 +59,15 @@ def request_server(
 
         elif method == Methods.post:
             response = requests.post(
+                f"{server}/{url}",
+                json=payload,
+                data=data,
+                headers=headers,
+                timeout=300,
+            )
+
+        elif method == Methods.delete:
+            response = requests.delete(
                 f"{server}/{url}",
                 json=payload,
                 data=data,

--- a/tests/unit/cli/admin/test_metadata.py
+++ b/tests/unit/cli/admin/test_metadata.py
@@ -7,8 +7,10 @@ import os
 from datetime import datetime, timedelta
 
 import pretend  # type: ignore
+import pytest
 from tuf.api.metadata import Metadata, Root
 
+from repository_service_tuf.cli import click
 from repository_service_tuf.cli.admin import metadata
 from repository_service_tuf.helpers.api_client import URL
 
@@ -1156,3 +1158,115 @@ class TestMetadataSignOptions:
                 "Metadata sign status:",
             )
         ]
+
+    def test_metadata_sign_delete(self, client, test_context):
+        input_step = [
+            "root",  # Choose a metadata to delete signing process [root]
+            "y",  # Do you still want to delete signing process root? [y]
+        ]
+
+        with open("tests/files/das-root.json", "r") as f:
+            das_root = f.read()
+
+        fake_response_data = {"data": {"metadata": json.loads(das_root)}}
+        fake_response = pretend.stub(
+            json=pretend.call_recorder(lambda: fake_response_data),
+            status_code=200,
+        )
+        metadata.request_server = pretend.call_recorder(
+            lambda *a, **kw: fake_response
+        )
+        metadata.send_payload = pretend.call_recorder(lambda *a: "fake-taskid")
+        metadata.task_status = pretend.call_recorder(lambda *a: "OK")
+
+        test_result = client.invoke(
+            metadata.sign,
+            ["--api-url", "http://127.0.0.1", "--delete"],
+            input="\n".join(input_step),
+            obj=test_context,
+            catch_exceptions=False,
+        )
+        assert test_result.exit_code == 0, test_result.output
+        assert "Signing process deleted!" in test_result.output
+
+        assert metadata.request_server.calls == [
+            pretend.call(
+                "http://127.0.0.1",
+                "api/v1/metadata/sign/",
+                metadata.Methods.get,
+                headers={},
+            ),
+            pretend.call(
+                "http://127.0.0.1",
+                "api/v1/metadata/sign/",
+                metadata.Methods.delete,
+                headers={},
+            ),
+        ]
+
+    def test_metadata_sign_delete_missing_url(self, client, test_context):
+        input_step = [
+            "http://127.0.0.1",  # Provide API URL address
+            "root",  # Choose a metadata to delete signing process [root]
+            "y",  # Do you still want to delete signing process root? [y]
+            "http://127.0.0.1",  # Provide API URL address
+        ]
+
+        with open("tests/files/das-root.json", "r") as f:
+            das_root = f.read()
+
+        fake_response_data = {"data": {"metadata": json.loads(das_root)}}
+        fake_response = pretend.stub(
+            json=pretend.call_recorder(lambda: fake_response_data),
+            status_code=200,
+        )
+        metadata.request_server = pretend.call_recorder(
+            lambda *a, **kw: fake_response
+        )
+        metadata.send_payload = pretend.call_recorder(lambda *a: "fake-taskid")
+        metadata.task_status = pretend.call_recorder(lambda *a: "OK")
+
+        test_result = client.invoke(
+            metadata.sign,
+            ["--delete"],
+            input="\n".join(input_step),
+            obj=test_context,
+            catch_exceptions=False,
+        )
+        assert test_result.exit_code == 0, test_result.output
+        assert "Signing process deleted!" in test_result.output
+
+        assert metadata.request_server.calls == [
+            pretend.call(
+                "http://127.0.0.1",
+                "api/v1/metadata/sign/",
+                metadata.Methods.get,
+                headers={},
+            ),
+            pretend.call(
+                "http://127.0.0.1",
+                "api/v1/metadata/sign/",
+                metadata.Methods.delete,
+                headers={},
+            ),
+        ]
+
+
+class TestMetadataFunctions:
+    def test_metadata_sign_delete_failure(self, test_context):
+        with open("tests/files/das-root.json", "r") as f:
+            das_root = f.read()
+
+        fake_response_data = {"data": {"metadata": json.loads(das_root)}}
+        fake_response = pretend.stub(
+            json=pretend.call_recorder(lambda: fake_response_data),
+            status_code=404,
+        )
+        metadata.request_server = pretend.call_recorder(
+            lambda *a, **kw: fake_response
+        )
+
+        obj = test_context["settings"]
+
+        with pytest.raises(click.ClickException):
+            metadata._delete_signing_process("root", obj, "http://127.0.0.1")

--- a/tests/unit/helpers/test_api_client.py
+++ b/tests/unit/helpers/test_api_client.py
@@ -61,6 +61,30 @@ class TestAPIClient:
             )
         ]
 
+    def test_request_server_delete(self):
+        fake_response = pretend.stub(
+            status_code=200,
+            json=pretend.call_recorder(lambda: {"key": "value"}),
+        )
+        api_client.requests = pretend.stub(
+            delete=pretend.call_recorder(lambda *a, **kw: fake_response)
+        )
+
+        result = api_client.request_server(
+            "http://server", "url", api_client.Methods.delete, {"k": "v"}
+        )
+
+        assert result == fake_response
+        assert api_client.requests.delete.calls == [
+            pretend.call(
+                "http://server/url",
+                json={"k": "v"},
+                data=None,
+                headers=None,
+                timeout=300,
+            )
+        ]
+
     def test_request_server_invalid_method(self):
         with pytest.raises(ValueError) as err:
             api_client.request_server(


### PR DESCRIPTION
This change allows deleting a signing process with `rstuf admin metadata sign --delete` with an input - a role whoose signate should be deleted and DAS signing process - terminated

Fixes #370


# Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [x] Tests have been added for the bug fix or new feature
- [tbd ] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct