### PR TITLE
Update `sign --delete` to the new API method and path

### DIFF
--- a/repository_service_tuf/cli/admin/metadata.py
+++ b/repository_service_tuf/cli/admin/metadata.py
@@ -718,8 +718,8 @@ def _delete_signing_process(
     headers = get_headers(settings)
     response = request_server(
         settings.SERVER,
-        URL.metadata_sign.value,
-        Methods.delete,
+        URL.metadata_sign_delete.value,
+        Methods.post,
         headers=headers,
     )
     if response.status_code != 200:

--- a/repository_service_tuf/helpers/api_client.py
+++ b/repository_service_tuf/helpers/api_client.py
@@ -24,6 +24,7 @@ class URL(Enum):
     task = "api/v1/task/?task_id="
     publish_targets = "api/v1/targets/publish/"
     metadata_sign = "api/v1/metadata/sign/"
+    metadata_sign_delete = "api/v1/metadata/sign/delete"
     artifacts = "api/v1/artifacts/"
 
 

--- a/tests/unit/cli/admin/test_metadata.py
+++ b/tests/unit/cli/admin/test_metadata.py
@@ -1198,8 +1198,8 @@ class TestMetadataSignOptions:
             ),
             pretend.call(
                 "http://127.0.0.1",
-                "api/v1/metadata/sign/",
-                metadata.Methods.delete,
+                "api/v1/metadata/sign/delete",
+                metadata.Methods.post,
                 headers={},
             ),
         ]
@@ -1245,8 +1245,8 @@ class TestMetadataSignOptions:
             ),
             pretend.call(
                 "http://127.0.0.1",
-                "api/v1/metadata/sign/",
-                metadata.Methods.delete,
+                "api/v1/metadata/sign/delete",
+                metadata.Methods.post,
                 headers={},
             ),
         ]


### PR DESCRIPTION
This change updates the `rstuf admin metadata sign --delete`
 command to use `POST api/v1/metadata/sign/delete` instead of 
the previuos `DELETE api/v1/metadata/sign` API

Fixes #409


# Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [x] Tests have been added for the bug fix or new feature
- [n/a ] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct