### PR TITLE
Fix `rstuf admin metadata sign --delete`

### DIFF
--- a/repository_service_tuf/cli/admin/metadata.py
+++ b/repository_service_tuf/cli/admin/metadata.py
@@ -706,28 +706,6 @@ def _sign_metadata(role_info: MetadataInfo, rstuf_key: RSTUFKey) -> Signature:
     return signature
 
 
-def _delete_signing_process(
-    role: str, settings: Any, api_url: Optional[str]
-) -> None:
-    if settings.AUTH is False and api_url is None:
-        api_url = prompt.Prompt.ask("\n[cyan]API[/] URL address")
-        settings.SERVER = api_url
-    elif settings.AUTH is False and api_url is not None:
-        settings.SERVER = api_url
-
-    headers = get_headers(settings)
-    response = request_server(
-        settings.SERVER,
-        URL.metadata_sign_delete.value,
-        Methods.post,
-        headers=headers,
-    )
-    if response.status_code != 200:
-        raise click.ClickException(
-            f"Failed to delete signing process. Error: {response}"
-        )
-
-
 @metadata.command()
 @click.option(
     "--api-url",
@@ -775,14 +753,13 @@ def sign(context, api_url: Optional[str], delete: Optional[bool]) -> None:
             break
 
     if delete:
-        _delete_signing_process(role_info.type, settings, api_url)
         payload = {"role": rolename}
         task_id = send_payload(
             settings,
-            URL.metadata_sign.value,
+            URL.metadata_sign_delete.value,
             payload,
             "Metadata delete sign accepted.",
-            "Metadata sign",
+            "Metadata delete sign",
         )
         task_status(task_id, settings, "Signing process status: ")
         console.print("\nSigning process deleted!\n")


### PR DESCRIPTION
This change fixes a potential bug in the `--delete` flag following
from the API method change from DELETE to POST, which
makes the initial approach non-optimal

Fixes #409


# Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [x] Tests have been added for the bug fix or new feature
- [n/a] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct