### PR TITLE
Change .ini config to .yaml/.yml

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,7 +12,7 @@ auto-click-auto = "*"
 PyNaCl = "==1.5.0"
 requests = "*"
 tuf = "==3.0.0"
-dynaconf = {extras = ["ini"], version = "*"}
+dynaconf = {extras = ["yaml"], version = "*"}
 isort = "*"
 sqlalchemy = "*"
 psycopg2 = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "cd759b890c04dc5f572106397098263b2f53affe06e842674d096105b4895be9"
+            "sha256": "202a5d0866da24c1a8d879d6ed8295f6a9f66bce5d36300823d47cd551ed5728"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -196,14 +196,6 @@
             "markers": "python_version >= '3.7'",
             "version": "==8.1.7"
         },
-        "configobj": {
-            "hashes": [
-                "sha256:6f704434a07dc4f4dc7c9a745172c1cad449feb548febd9f7fe362629c627a97",
-                "sha256:a7a8c6ab7daade85c3f329931a807c8aee750a2494363934f8ea84d8a54c87ea",
-                "sha256:d808d7e04e6f81fbb23d5ac2cd50e69ccbee58eaf9360eb89ede22d93216a314"
-            ],
-            "version": "==5.0.8"
-        },
         "cryptography": {
             "hashes": [
                 "sha256:004b6ccc95943f6a9ad3142cfabcc769d7ee38a3f60fb0dddbfb431f818c3a67",
@@ -234,7 +226,7 @@
         },
         "dynaconf": {
             "extras": [
-                "ini"
+                "yaml"
             ],
             "hashes": [
                 "sha256:8a37ba3b16df64cb1db383eaad9c733aece218413be0fad5d785f7a907612106",
@@ -420,6 +412,55 @@
             "markers": "python_version >= '3.7'",
             "version": "==1.7.0"
         },
+        "ruamel.yaml": {
+            "hashes": [
+                "sha256:801046a9caacb1b43acc118969b49b96b65e8847f29029563b29ac61d02db61b",
+                "sha256:b105e3e6fc15b41fdb201ba1b95162ae566a4ef792b9f884c46b4ccc5513a87a"
+            ],
+            "version": "==0.17.35"
+        },
+        "ruamel.yaml.clib": {
+            "hashes": [
+                "sha256:03d1162b6d1df1caa3a4bd27aa51ce17c9afc2046c31b0ad60a0a96ec22f8001",
+                "sha256:07238db9cbdf8fc1e9de2489a4f68474e70dffcb32232db7c08fa61ca0c7c462",
+                "sha256:1b617618914cb00bf5c34d4357c37aa15183fa229b24767259657746c9077615",
+                "sha256:25ac8c08322002b06fa1d49d1646181f0b2c72f5cbc15a85e80b4c30a544bb15",
+                "sha256:25c515e350e5b739842fc3228d662413ef28f295791af5e5110b543cf0b57d9b",
+                "sha256:3f215c5daf6a9d7bbed4a0a4f760f3113b10e82ff4c5c44bec20a68c8014f675",
+                "sha256:3fcc54cb0c8b811ff66082de1680b4b14cf8a81dce0d4fbf665c2265a81e07a1",
+                "sha256:53a300ed9cea38cf5a2a9b069058137c2ca1ce658a874b79baceb8f892f915a7",
+                "sha256:56f4252222c067b4ce51ae12cbac231bce32aee1d33fbfc9d17e5b8d6966c312",
+                "sha256:665f58bfd29b167039f714c6998178d27ccd83984084c286110ef26b230f259f",
+                "sha256:700e4ebb569e59e16a976857c8798aee258dceac7c7d6b50cab63e080058df91",
+                "sha256:7048c338b6c86627afb27faecf418768acb6331fc24cfa56c93e8c9780f815fa",
+                "sha256:75e1ed13e1f9de23c5607fe6bd1aeaae21e523b32d83bb33918245361e9cc51b",
+                "sha256:7f67a1ee819dc4562d444bbafb135832b0b909f81cc90f7aa00260968c9ca1b3",
+                "sha256:84b554931e932c46f94ab306913ad7e11bba988104c5cff26d90d03f68258cd5",
+                "sha256:955eae71ac26c1ab35924203fda6220f84dce57d6d7884f189743e2abe3a9fbe",
+                "sha256:9eb5dee2772b0f704ca2e45b1713e4e5198c18f515b52743576d196348f374d3",
+                "sha256:a5aa27bad2bb83670b71683aae140a1f52b0857a2deff56ad3f6c13a017a26ed",
+                "sha256:a6a9ffd280b71ad062eae53ac1659ad86a17f59a0fdc7699fd9be40525153337",
+                "sha256:b16420e621d26fdfa949a8b4b47ade8810c56002f5389970db4ddda51dbff248",
+                "sha256:b42169467c42b692c19cf539c38d4602069d8c1505e97b86387fcf7afb766e1d",
+                "sha256:b5edda50e5e9e15e54a6a8a0070302b00c518a9d32accc2346ad6c984aacd279",
+                "sha256:bba64af9fa9cebe325a62fa398760f5c7206b215201b0ec825005f1b18b9bccf",
+                "sha256:beb2e0404003de9a4cab9753a8805a8fe9320ee6673136ed7f04255fe60bb512",
+                "sha256:bef08cd86169d9eafb3ccb0a39edb11d8e25f3dae2b28f5c52fd997521133069",
+                "sha256:c2a72e9109ea74e511e29032f3b670835f8a59bbdc9ce692c5b4ed91ccf1eedb",
+                "sha256:c58ecd827313af6864893e7af0a3bb85fd529f862b6adbefe14643947cfe2942",
+                "sha256:c69212f63169ec1cfc9bb44723bf2917cbbd8f6191a00ef3410f5a7fe300722d",
+                "sha256:cabddb8d8ead485e255fe80429f833172b4cadf99274db39abc080e068cbcc31",
+                "sha256:d176b57452ab5b7028ac47e7b3cf644bcfdc8cacfecf7e71759f7f51a59e5c92",
+                "sha256:d92f81886165cb14d7b067ef37e142256f1c6a90a65cd156b063a43da1708cfd",
+                "sha256:da09ad1c359a728e112d60116f626cc9f29730ff3e0e7db72b9a2dbc2e4beed5",
+                "sha256:ebc06178e8821efc9692ea7544aa5644217358490145629914d8020042c24aa1",
+                "sha256:edaef1c1200c4b4cb914583150dcaa3bc30e592e907c01117c08b13a07255ec2",
+                "sha256:f481f16baec5290e45aebdc2a5168ebc6d35189ae6fea7a58787613a25f6e875",
+                "sha256:fff3573c2db359f091e1589c3d7c5fc2f86f5bdb6f24252c2d8e539d4e45f412"
+            ],
+            "markers": "python_version < '3.13' and platform_python_implementation == 'CPython'",
+            "version": "==0.2.8"
+        },
         "securesystemslib": {
             "extras": [
                 "crypto"
@@ -430,14 +471,6 @@
             ],
             "markers": "python_version ~= '3.7'",
             "version": "==0.28.0"
-        },
-        "six": {
-            "hashes": [
-                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
-                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.16.0"
         },
         "sqlalchemy": {
             "hashes": [

--- a/docs/source/devel/design.rst
+++ b/docs/source/devel/design.rst
@@ -17,7 +17,7 @@ The ``repository-service-tuf``, in the container perspective, is a command line 
 interacts to the ``repository-service-tuf-api``.
 
 ``repository-service-tuf`` reads the settings configuration from config file
-See: ``--config/-c``, default: ``$HOME/.rstuf.ini``.
+See: ``--config/-c``, default: ``$HOME/.rstuf.yml``.
 
 ``repository-service-tuf`` writes the ``payload.json`` or the specified file
 with option ``-f/--file`` with ``ceremony`` subcommand.

--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -23,7 +23,7 @@ Using pip:
     Repository Service for TUF Command Line Interface (CLI).
 
     ╭─ Options ────────────────────────────────────────────────────────────────────────────────╮
-    │ --config   -c  TEXT  Repository Service for TUF config file. [default: $HOME/.rstuf.ini] │
+    │ --config   -c  TEXT  Repository Service for TUF config file. [default: $HOME/.rstuf.yml] │
     │ --version            Show the version and exit.                                          │
     │ --help     -h        Show this message and exit.                                         │
     ╰──────────────────────────────────────────────────────────────────────────────────────────╯

--- a/repository_service_tuf/cli/__init__.py
+++ b/repository_service_tuf/cli/__init__.py
@@ -43,7 +43,7 @@ except FileNotFoundError:  # pragma: no cover the tests will fail in general
     "-c",
     "--config",
     "config",
-    default=os.path.join(HOME, ".rstuf.ini"),
+    default=os.path.join(HOME, ".rstuf.yml"),
     help="Repository Service for TUF config file.",
     show_default=True,
     required=False,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -75,15 +75,15 @@ virtualenv==20.24.5; python_version >= '3.7'
 zipp==3.17.0; python_version >= '3.8'
 auto-click-auto==0.1.1; python_version >= '3.7' and python_version < '4.0'
 cffi==1.16.0; python_version >= '3.8'
-configobj==5.0.8
 cryptography==41.0.4
-dynaconf[ini]==3.2.3; python_version >= '3.8'
+dynaconf[yaml]==3.2.3; python_version >= '3.8'
 greenlet==3.0.0; platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))
 psycopg2==2.9.9; python_version >= '3.7'
 pycparser==2.21
 pynacl==1.5.0; python_version >= '3.6'
 rich-click==1.7.0; python_version >= '3.7'
+ruamel.yaml==0.17.35
+ruamel.yaml.clib==0.2.8; python_version < '3.13' and platform_python_implementation == 'CPython'
 securesystemslib[crypto]==0.28.0; python_version ~= '3.7'
-six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 sqlalchemy==2.0.21; python_version >= '3.7'
 tuf==3.0.0; python_version >= '3.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,8 @@ certifi==2023.7.22; python_version >= '3.6'
 cffi==1.16.0; python_version >= '3.8'
 charset-normalizer==3.3.0; python_full_version >= '3.7.0'
 click==8.1.7; python_version >= '3.7'
-configobj==5.0.8
 cryptography==41.0.4
-dynaconf[ini]==3.2.3; python_version >= '3.8'
+dynaconf[yaml]==3.2.3; python_version >= '3.8'
 greenlet==3.0.0; platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))
 idna==3.4; python_version >= '3.5'
 isort==5.12.0; python_full_version >= '3.8.0'
@@ -19,8 +18,9 @@ pynacl==1.5.0; python_version >= '3.6'
 requests==2.31.0; python_version >= '3.7'
 rich==13.6.0; python_full_version >= '3.7.0'
 rich-click==1.7.0; python_version >= '3.7'
+ruamel.yaml==0.17.35
+ruamel.yaml.clib==0.2.8; python_version < '3.13' and platform_python_implementation == 'CPython'
 securesystemslib[crypto]==0.28.0; python_version ~= '3.7'
-six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 sqlalchemy==2.0.21; python_version >= '3.7'
 tuf==3.0.0; python_version >= '3.7'
 typing-extensions==4.8.0; python_version >= '3.8'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ from repository_service_tuf.helpers.tuf import (
 
 @pytest.fixture
 def test_context() -> Dict[str, Any]:
-    setting_file = os.path.join(TemporaryDirectory().name, "test_settings.ini")
+    setting_file = os.path.join(TemporaryDirectory().name, "test_settings.yml")
     test_settings = Dynaconf(settings_files=[setting_file])
     return {"settings": test_settings, "config": setting_file}
 


### PR DESCRIPTION
As `.ini` is recomended mainly for legacy, while `yaml` fomat has many benefits (can convert to json, allows more complex configuration and is the recomended format for Django) this change migrates the config to use yaml

Fixes #332


# Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [n/a ] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct