### PR TITLE
Small refactoring and reuse one `get_key()` for all commands 

### DIFF
--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -192,7 +192,7 @@ Step 2: Load the Online Key
 
     🔑 Key 1/1 ONLINE
 
-    Select the ONLINE`s key type [ed25519/ecdsa/rsa] (ed25519):
+    Choose ONLINE`s key type [ed25519/ecdsa/rsa] (ed25519):
     Enter ONLINE`s key id: f7a6872f297634219a80141caa2ec9ae8802098b07b67963272603e36cc19fd8
     Enter ONLINE`s public key hash: 9fe7ddccb75b977a041424a1fdc142e01be4abab918dc4c611fbfe4a3360a9a8
     [Optional] Give a name/tag to the root`s key:
@@ -224,7 +224,7 @@ to load their keys.
 
     🔑 Key 1/2 root
 
-    Select the root`s key type [ed25519/ecdsa/rsa] (ed25519):
+    Choose root`s key type [ed25519/ecdsa/rsa] (ed25519):
     Enter the root`s private key path: tests/files/key_storage/JanisJoplin.key
     Enter the root`s private key password:
     [Optional] Give a name/tag to the key: Janis Joplin
@@ -237,7 +237,7 @@ to load their keys.
     - public info requires the a key id and key hash
     tip: `rstuf key info` retrieves the public information
     Select to use private key or public? [private/public] (public):
-    Select the root`s key type [ed25519/ecdsa/rsa] (ed25519):
+    Choose root`s key type [ed25519/ecdsa/rsa] (ed25519):
     Enter root`s key id: 800dfb5a1982b82b7893e58035e19f414f553fc08cbb1130cfbae302a7b7fee5
     Enter root`s public key hash: 7098f769f6ab8502b50f3b58686b8a042d5d3bb75d8b3a48a2fcbc15a0223501
     [Optional] Give a name/tag to the root`s key: Jimi Hendrix

--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -195,7 +195,7 @@ Step 2: Load the Online Key
     Select the ONLINE`s key type [ed25519/ecdsa/rsa] (ed25519):
     Enter ONLINE`s key id: f7a6872f297634219a80141caa2ec9ae8802098b07b67963272603e36cc19fd8
     Enter ONLINE`s public key hash: 9fe7ddccb75b977a041424a1fdc142e01be4abab918dc4c611fbfe4a3360a9a8
-    Give a name/tag to the key [Optional]:
+    [Optional] Give a name/tag to the root`s key:
 
 
 Step 3: Load Root Keys
@@ -240,7 +240,7 @@ to load their keys.
     Select the root`s key type [ed25519/ecdsa/rsa] (ed25519):
     Enter root`s key id: 800dfb5a1982b82b7893e58035e19f414f553fc08cbb1130cfbae302a7b7fee5
     Enter root`s public key hash: 7098f769f6ab8502b50f3b58686b8a042d5d3bb75d8b3a48a2fcbc15a0223501
-    Give a name/tag to the key [Optional]: Jimi Hendrix
+    [Optional] Give a name/tag to the root`s key: Jimi Hendrix
 
 Step 4: Validate Configuration
 ..............................

--- a/repository_service_tuf/cli/admin/ceremony.py
+++ b/repository_service_tuf/cli/admin/ceremony.py
@@ -25,8 +25,8 @@ from repository_service_tuf.helpers.tuf import (
     RSTUFKey,
     ServiceSettings,
     TUFManagement,
-    get_supported_schemes_for_key_type,
     get_key,
+    get_supported_schemes_for_key_type,
     load_payload,
     save_payload,
 )

--- a/repository_service_tuf/cli/admin/ceremony.py
+++ b/repository_service_tuf/cli/admin/ceremony.py
@@ -369,7 +369,7 @@ def _configure_keys(
             )
 
         key_type = prompt.Prompt.ask(
-            f"Select the {role_cyan}`s key type",
+            f"Choose {role_cyan}`s key type",
             choices=KeyType.get_all_members(),
             default=KeyType.KEY_TYPE_ED25519.value,
         )

--- a/repository_service_tuf/cli/admin/ceremony.py
+++ b/repository_service_tuf/cli/admin/ceremony.py
@@ -26,7 +26,7 @@ from repository_service_tuf.helpers.tuf import (
     ServiceSettings,
     TUFManagement,
     get_supported_schemes_for_key_type,
-    load_key,
+    get_key,
     load_payload,
     save_payload,
 )
@@ -374,19 +374,7 @@ def _configure_keys(
             default=KeyType.KEY_TYPE_ED25519.value,
         )
         if signing_key == "private":
-            filepath = prompt.Prompt.ask(
-                f"Enter the {role_cyan}`s [green]private key path[/]"
-            )
-            password_green = click.style("private key password", fg="green")
-            password = click.prompt(
-                f"Enter the {role_cyan}`s {password_green}", hide_input=True
-            )
-            name = prompt.Prompt.ask(
-                f"[Optional] Give a [green]name/tag[/] to the {role_cyan} key",
-                default="",
-                show_default=False,
-            )
-            role_key: RSTUFKey = load_key(filepath, key_type, password, name)
+            role_key: RSTUFKey = get_key(role, key_type, ask_name=True)
             if role_key.error:
                 console.print(role_key.error)
 
@@ -402,7 +390,7 @@ def _configure_keys(
                 scheme = allowed_schemes[0]
             else:
                 scheme = prompt.Prompt.ask(
-                    f"Choose {colored_role}`s [green]public key scheme[/]",
+                    f"Choose {role_cyan}`s [green]public key scheme[/]",
                     choices=allowed_schemes,
                     default=SCHEME_DEFAULTS[key_type],
                 )

--- a/repository_service_tuf/cli/admin/ceremony.py
+++ b/repository_service_tuf/cli/admin/ceremony.py
@@ -344,7 +344,7 @@ def _configure_role(role: Roles) -> None:
 def _configure_keys(
     role: str, number_of_keys: int
 ) -> Generator[RSTUFKey, None, None]:
-    colored_role = click.style(role, fg="cyan")
+    role_cyan = click.style(role, fg="cyan")
     key_count = 1
     while key_count <= number_of_keys:
         console.print(
@@ -369,21 +369,20 @@ def _configure_keys(
             )
 
         key_type = prompt.Prompt.ask(
-            f"Select the {colored_role}`s key type",
+            f"Select the {role_cyan}`s key type",
             choices=KeyType.get_all_members(),
             default=KeyType.KEY_TYPE_ED25519.value,
         )
         if signing_key == "private":
             filepath = prompt.Prompt.ask(
-                f"Enter the {colored_role}`s [green]private key path[/]"
+                f"Enter the {role_cyan}`s [green]private key path[/]"
             )
-
+            password_green = click.style("private key password", fg="green")
             password = click.prompt(
-                f"Enter the {colored_role}`s private key password",
-                hide_input=True,
+                f"Enter the {role_cyan}`s {password_green}", hide_input=True
             )
             name = prompt.Prompt.ask(
-                "[Optional] Give a name/tag to the key",
+                f"[Optional] Give a [green]name/tag[/] to the {role_cyan} key",
                 default="",
                 show_default=False,
             )
@@ -410,20 +409,20 @@ def _configure_keys(
 
             while True:
                 keyid = prompt.Prompt.ask(
-                    f"Enter {colored_role}`s [green]key id[/]"
+                    f"Enter {role_cyan}`s [green]key id[/]"
                 )
                 if keyid.strip() != "":
                     break
 
             while True:
                 public = prompt.Prompt.ask(
-                    f"Enter {colored_role}`s [green]public key hash[/]"
+                    f"Enter {role_cyan}`s [green]public key hash[/]"
                 )
                 if public.strip() != "":
                     break
 
             name = prompt.Prompt.ask(
-                "Give a name/tag to the key [Optional]",
+                f"[Optional] Give a [green]name/tag[/] to the {role_cyan} key",
                 default=keyid[:7],
                 show_default=False,
             )

--- a/repository_service_tuf/cli/admin/metadata.py
+++ b/repository_service_tuf/cli/admin/metadata.py
@@ -310,7 +310,7 @@ def _keys_additions(root_info: MetadataInfo):
         else:
             console.print(f"You must add {signing_keys_needed} more key(s)")
 
-        root_key: RSTUFKey = get_key(Root.type)
+        root_key: RSTUFKey = get_key(Root.type, "", ask_name=True)
         if root_key.error:
             console.print(root_key.error)
             continue
@@ -325,10 +325,6 @@ def _keys_additions(root_info: MetadataInfo):
         if root_info.is_keyid_used(root_key.key["keyid"]):
             console.print(":cross_mark: [red]Failed[/]: Key is already used")
             continue
-
-        root_key.name = prompt.Prompt.ask(
-            "[Optional] Give a [green]name/tag[/] to the key"
-        )
 
         root_info.add_key(root_key)
 
@@ -423,7 +419,7 @@ def _modify_online_key(root_info: MetadataInfo):
             console.print("Skipping further online key changes")
             break
 
-        online_key: RSTUFKey = get_key("online")
+        online_key: RSTUFKey = get_key("online", ask_name=True)
         if online_key.error:
             console.print(online_key.error)
             continue
@@ -439,10 +435,6 @@ def _modify_online_key(root_info: MetadataInfo):
                 ":cross_mark: [red]Failed[/]: Key matches one of the root keys"
             )
             continue
-
-        online_key.name = prompt.Prompt.ask(
-            "[Optional] Give a [green]name/tag[/] to the key"
-        )
 
         root_info.change_online_key(online_key)
 

--- a/repository_service_tuf/cli/admin/metadata.py
+++ b/repository_service_tuf/cli/admin/metadata.py
@@ -14,7 +14,6 @@ from tuf.api.serialization import DeserializationError
 
 from repository_service_tuf.cli import click, console
 from repository_service_tuf.cli.admin import admin
-from repository_service_tuf.constants import KeyType
 from repository_service_tuf.helpers.api_client import (
     URL,
     Methods,
@@ -27,7 +26,7 @@ from repository_service_tuf.helpers.tuf import (
     MetadataInfo,
     RSTUFKey,
     UnsignedMetadataError,
-    load_key,
+    get_key,
     load_payload,
     save_payload,
 )
@@ -204,25 +203,6 @@ def _print_md_info(md_info: MetadataInfo, trusted_md: Optional[bool] = True):
     console.print("\n")
 
 
-def _get_key(role: str) -> RSTUFKey:
-    key_type = prompt.Prompt.ask(
-        f"\nChoose [cyan]{role}[/] key type",
-        choices=KeyType.get_all_members(),
-        default=KeyType.KEY_TYPE_ED25519.value,
-    )
-    filepath = prompt.Prompt.ask(
-        f"Enter the [cyan]{role}[/]`s private key [green]path[/]"
-    )
-    colored_role = click.style(role, fg="cyan")
-    colored_pass = click.style("password", fg="green")
-    password = click.prompt(
-        f"Enter the {colored_role}`s private key {colored_pass}",
-        hide_input=True,
-    )
-
-    return load_key(filepath, key_type, password, "")
-
-
 def _is_valid_current_key(
     keyid: str, root_info: MetadataInfo, already_loaded_keyids: List[str]
 ) -> bool:
@@ -261,7 +241,7 @@ def _current_md_keys_validation(root_info: MetadataInfo):
         console.print(
             f"You will enter information for key {key_count} of {threshold}"
         )
-        root_key: RSTUFKey = _get_key(Root.type)
+        root_key: RSTUFKey = get_key(Root.type)
         if root_key.error:
             console.print(f"Failed loading key {key_count} of {threshold}")
             console.print(root_key.error)
@@ -330,7 +310,7 @@ def _keys_additions(root_info: MetadataInfo):
         else:
             console.print(f"You must add {signing_keys_needed} more key(s)")
 
-        root_key: RSTUFKey = _get_key(Root.type)
+        root_key: RSTUFKey = get_key(Root.type)
         if root_key.error:
             console.print(root_key.error)
             continue
@@ -443,7 +423,7 @@ def _modify_online_key(root_info: MetadataInfo):
             console.print("Skipping further online key changes")
             break
 
-        online_key: RSTUFKey = _get_key("online")
+        online_key: RSTUFKey = get_key("online")
         if online_key.error:
             console.print(online_key.error)
             continue
@@ -670,7 +650,7 @@ def _get_signing_key(role_info: MetadataInfo) -> RSTUFKey:
     )
 
     while True:
-        rstuf_key = _get_key(sign_key_name)
+        rstuf_key: RSTUFKey = get_key(sign_key_name)
         if rstuf_key.error:
             console.print(rstuf_key.error)
             retry = prompt.Confirm.ask(

--- a/repository_service_tuf/cli/key/info.py
+++ b/repository_service_tuf/cli/key/info.py
@@ -1,44 +1,26 @@
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT
-from rich import prompt
 from rich.console import Console  # type: ignore
 
 from repository_service_tuf.cli import click
 from repository_service_tuf.cli.key import key
-from repository_service_tuf.constants import KeyType
 from repository_service_tuf.helpers.tuf import (
     RSTUFKey,
-    load_key,
+    get_key,
     print_key_table,
 )
 
 console = Console()
 
 
-def _get_key() -> RSTUFKey:
-    keytype: str = prompt.Prompt.ask(
-        "\nChoose key type",
-        choices=KeyType.get_all_members(),
-        default=KeyType.KEY_TYPE_ED25519.value,
-    )
-    filepath: str = prompt.Prompt.ask(
-        "Enter the private key's [green]file name[/]"
-    )
-    password_green = click.style("private key password", fg="green")
-    password: str = click.prompt(
-        f"Enter the {password_green}", hide_input=True
-    )
-
-    return load_key(filepath, keytype, password, "")
-
-
 @key.command()
 def info() -> None:
     """Show key information"""
 
-    rstuf_key = _get_key()
+    rstuf_key: RSTUFKey = get_key()
     if rstuf_key.error:
         console.print(rstuf_key.error)
         raise click.ClickException("Failed to load the Key")
+
     print_key_table(rstuf_key)

--- a/repository_service_tuf/cli/key/info.py
+++ b/repository_service_tuf/cli/key/info.py
@@ -25,8 +25,9 @@ def _get_key() -> RSTUFKey:
     filepath: str = prompt.Prompt.ask(
         "Enter the private key's [green]file name[/]"
     )
+    password_green = click.style("private key password", fg="green")
     password: str = click.prompt(
-        "Enter the private key password", hide_input=True
+        f"Enter the {password_green}", hide_input=True
     )
 
     return load_key(filepath, keytype, password, "")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,19 +81,19 @@ def test_inputs() -> Tuple[List[str], List[str], List[str], List[str]]:
         "",  # What is the metadata expiration for the bins role?(Days) (365)?
     ]
     input_step2 = [
-        "",  # Select the ONLINE`s key type [ed25519/ecdsa/rsa] (ed25519)
+        "",  # Choose ONLINE`s key type [ed25519/ecdsa/rsa] (ed25519)
         "f7a6872f297634219a80141caa2ec9ae8802098b07b67963272603e36cc19fd8",  # Enter ONLINE`s key id  # noqa
         "9fe7ddccb75b977a041424a1fdc142e01be4abab918dc4c611fbfe4a3360a9a8",  # Enter ONLINE`s public key hash   # noqa
         "",  # [Optional] Give a name/tag to the root`s key
     ]
     input_step3 = [
         "y",  # Ready to start loading the root keys? [y/n]
-        "",  # Select the root`s key type [ed25519/ecdsa/rsa] (ed25519)
+        "",  # Choose root`s key type [ed25519/ecdsa/rsa] (ed25519)
         "tests/files/key_storage/JanisJoplin.key",  # Enter the root`s private key path  # noqa
         "strongPass",  # Enter the root`s private key password
         "",  # [Optional] Give a name/tag to the root`s key
         "private",  # Select to use private key or public? [private/public] (public)  # noqa
-        "",  # Select the root`s key type [ed25519/ecdsa/rsa] (ed25519)
+        "",  # Choose root`s key type [ed25519/ecdsa/rsa] (ed25519)
         "tests/files/key_storage/JimiHendrix.key",  # Enter the root`s private key path  # noqa
         "strongPass",  # Enter the root`s private key password
         "",  # [Optional] Give a name/tag to the root`s key

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,19 +84,19 @@ def test_inputs() -> Tuple[List[str], List[str], List[str], List[str]]:
         "",  # Select the ONLINE`s key type [ed25519/ecdsa/rsa] (ed25519)
         "f7a6872f297634219a80141caa2ec9ae8802098b07b67963272603e36cc19fd8",  # Enter ONLINE`s key id  # noqa
         "9fe7ddccb75b977a041424a1fdc142e01be4abab918dc4c611fbfe4a3360a9a8",  # Enter ONLINE`s public key hash   # noqa
-        "",  # Give a name/tag to the key [Optional]
+        "",  # [Optional] Give a name/tag to the root`s key
     ]
     input_step3 = [
         "y",  # Ready to start loading the root keys? [y/n]
         "",  # Select the root`s key type [ed25519/ecdsa/rsa] (ed25519)
         "tests/files/key_storage/JanisJoplin.key",  # Enter the root`s private key path  # noqa
         "strongPass",  # Enter the root`s private key password
-        "",  # Give a name/tag to the key [Optional]
+        "",  # [Optional] Give a name/tag to the root`s key
         "private",  # Select to use private key or public? [private/public] (public)  # noqa
         "",  # Select the root`s key type [ed25519/ecdsa/rsa] (ed25519)
         "tests/files/key_storage/JimiHendrix.key",  # Enter the root`s private key path  # noqa
         "strongPass",  # Enter the root`s private key password
-        "",  # Give a name/tag to the key [Optional]
+        "",  # [Optional] Give a name/tag to the root`s key
     ]
     input_step4 = [
         "y",  # Is the online key configuration correct? [y/n]

--- a/tests/unit/cli/admin/test_ceremony.py
+++ b/tests/unit/cli/admin/test_ceremony.py
@@ -96,12 +96,12 @@ class TestCeremonyInteraction:
 
         input_step3 = [
             "y",  # Ready to start loading the root keys? [y/n]
-            "",  # Select the root`s key type [ed25519/ecdsa/rsa] (ed25519)
+            "",  # Choose root`s key type [ed25519/ecdsa/rsa] (ed25519)
             "tests/files/key_storage/JanisJoplin.key",  # Enter the root`s private key path  # noqa
             "strongPass",  # Enter the root`s private key password
             "",  # [Optional] Give a name/tag to the root`s key
             "",  # Select to use private key or public? [private/public] (public)  # noqa
-            "",  # Select the root`s key type [ed25519/ecdsa/rsa] (ed25519)
+            "",  # Choose root`s key type [ed25519/ecdsa/rsa] (ed25519)
             "fake_id",  # # Enter root`s key id
             "fake_hash",  # Enter root`s public key hash
             "root key 2",  # [Optional] Give a name/tag to the root`s key
@@ -130,12 +130,12 @@ class TestCeremonyInteraction:
 
         input_step3 = [
             "y",  # Ready to start loading the root keys? [y/n]
-            "",  # Select the root`s key type [ed25519/ecdsa/rsa] (ed25519)
+            "",  # Choose root`s key type [ed25519/ecdsa/rsa] (ed25519)
             "tests/files/key_storage/JanisJoplin.key",  # Enter the root`s private key path  # noqa
             "strongPass",  # Enter the root`s private key password
             "",  # [Optional] Give a name/tag to the root`s key
             "",  # Select to use private key or public? [private/public] (public)  # noqa
-            "",  # Select the root`s key type [ed25519/ecdsa/rsa] (ed25519)
+            "",  # Choose root`s key type [ed25519/ecdsa/rsa] (ed25519)
             "",  # # Enter root`s key id
             "fake_id",  # # Enter root`s key id
             "",  # Enter root`s public key hash
@@ -205,16 +205,16 @@ class TestCeremonyInteraction:
         # overwrite the input_step2
         input_step3 = [
             "y",  # Ready to start loading the root keys? [y/n]
-            "",  # Select the root`s key type [ed25519/ecdsa/rsa]
+            "",  # Choose root`s key type [ed25519/ecdsa/rsa]
             "tests/files/key_storage/JanisJoplin.key",  # Enter the root`s private key path  # noqa
             "wrong password",  # Enter the root`s private key password
             "",  # [Optional] Give a name/tag to the root`s key
-            "",  # Select the root`s key type [ed25519/ecdsa/rsa] (ed25519)
+            "",  # Choose root`s key type [ed25519/ecdsa/rsa] (ed25519)
             "tests/files/key_storage/JanisJoplin.key",  # Enter the root`s private key path  # noqa
             "strongPass",  # Enter the root`s private key password
             "",  # [Optional] Give a name/tag to the root`s key
             "private",  # Select to use private key or public? [private/public] (public)  # noqa
-            "",  # Select the root`s key type [ed25519/ecdsa/rsa] (ed25519)
+            "",  # Choose root`s key type [ed25519/ecdsa/rsa] (ed25519)
             "tests/files/key_storage/JimiHendrix.key",  # Enter the root`s private key path  # noqa
             "strongPass",  # Enter the root`s private key password
             "",  # [Optional] Give a name/tag to the root`s key
@@ -267,7 +267,7 @@ class TestCeremonyInteraction:
         # overwrite the input_step3 with same key in input_step2 (online key)
         input_step3 = [
             "y",  # Ready to start loading the root keys? [y/n]
-            "",  # Select the root`s key type [ed25519/ecdsa/rsa] (ed25519)
+            "",  # Choose root`s key type [ed25519/ecdsa/rsa] (ed25519)
             "tests/files/key_storage/online.key",  # Enter the root`s private key path  # noqa
             "strongPass",  # Enter the root`s private key password
             "",  # [Optional] Give a name/tag to the root`s key

--- a/tests/unit/cli/admin/test_ceremony.py
+++ b/tests/unit/cli/admin/test_ceremony.py
@@ -99,12 +99,12 @@ class TestCeremonyInteraction:
             "",  # Select the root`s key type [ed25519/ecdsa/rsa] (ed25519)
             "tests/files/key_storage/JanisJoplin.key",  # Enter the root`s private key path  # noqa
             "strongPass",  # Enter the root`s private key password
-            "",  # Give a name/tag to the key [Optional]
+            "",  # [Optional] Give a name/tag to the root`s key
             "",  # Select to use private key or public? [private/public] (public)  # noqa
             "",  # Select the root`s key type [ed25519/ecdsa/rsa] (ed25519)
             "fake_id",  # # Enter root`s key id
             "fake_hash",  # Enter root`s public key hash
-            "root key 2",  # Give a name/tag to the key [Optional]
+            "root key 2",  # [Optional] Give a name/tag to the root`s key
             "",
         ]
 
@@ -133,14 +133,14 @@ class TestCeremonyInteraction:
             "",  # Select the root`s key type [ed25519/ecdsa/rsa] (ed25519)
             "tests/files/key_storage/JanisJoplin.key",  # Enter the root`s private key path  # noqa
             "strongPass",  # Enter the root`s private key password
-            "",  # Give a name/tag to the key [Optional]
+            "",  # [Optional] Give a name/tag to the root`s key
             "",  # Select to use private key or public? [private/public] (public)  # noqa
             "",  # Select the root`s key type [ed25519/ecdsa/rsa] (ed25519)
             "",  # # Enter root`s key id
             "fake_id",  # # Enter root`s key id
             "",  # Enter root`s public key hash
             "fake_hash",  # Enter root`s public key hash
-            "",  # Give a name/tag to the key [Optional]
+            "",  # [Optional] Give a name/tag to the root`s key
             "",
         ]
 
@@ -208,16 +208,16 @@ class TestCeremonyInteraction:
             "",  # Select the root`s key type [ed25519/ecdsa/rsa]
             "tests/files/key_storage/JanisJoplin.key",  # Enter the root`s private key path  # noqa
             "wrong password",  # Enter the root`s private key password
-            "",  # Give a name/tag to the key [Optional]
+            "",  # [Optional] Give a name/tag to the root`s key
             "",  # Select the root`s key type [ed25519/ecdsa/rsa] (ed25519)
             "tests/files/key_storage/JanisJoplin.key",  # Enter the root`s private key path  # noqa
             "strongPass",  # Enter the root`s private key password
-            "",  # Give a name/tag to the key [Optional]
+            "",  # [Optional] Give a name/tag to the root`s key
             "private",  # Select to use private key or public? [private/public] (public)  # noqa
             "",  # Select the root`s key type [ed25519/ecdsa/rsa] (ed25519)
             "tests/files/key_storage/JimiHendrix.key",  # Enter the root`s private key path  # noqa
             "strongPass",  # Enter the root`s private key password
-            "",  # Give a name/tag to the key [Optional]
+            "",  # [Optional] Give a name/tag to the root`s key
         ]
 
         test_result = client.invoke(
@@ -240,7 +240,7 @@ class TestCeremonyInteraction:
         ceremony.setup = test_setup
         input_step1, input_step2, input_step3, input_step4 = test_inputs
 
-        # update all: Give a name/tag to the key [Optional]
+        # update all: [Optional] Give a name/tag to the root`s key
         input_step2[-1] = "Online key"
         input_step3[4] = "Martin's Key"
         input_step3[9] = "Steven's Key"
@@ -270,16 +270,16 @@ class TestCeremonyInteraction:
             "",  # Select the root`s key type [ed25519/ecdsa/rsa] (ed25519)
             "tests/files/key_storage/online.key",  # Enter the root`s private key path  # noqa
             "strongPass",  # Enter the root`s private key password
-            "",  # Give a name/tag to the key [Optional]
+            "",  # [Optional] Give a name/tag to the root`s key
             "",  # Choose 1/2 root key type [ed25519/ecdsa/rsa]
             "tests/files/key_storage/JanisJoplin.key",  # Enter the root`s private key path  # noqa
             "strongPass",  # Enter the root`s private key password
-            "",  # Give a name/tag to the key [Optional]
+            "",  # [Optional] Give a name/tag to the root`s key
             "private",  # Select to use private key or public? [private/public] (public)  # noqa
             "",  # Choose 2/2 root key type [ed25519/ecdsa/rsa]
             "tests/files/key_storage/JimiHendrix.key",  # Enter the root`s private key path  # noqa
             "strongPass",  # Enter the root`s private key password
-            "",  # Give a name/tag to the key [Optional]
+            "",  # [Optional] Give a name/tag to the root`s key
         ]
 
         test_result = client.invoke(

--- a/tests/unit/cli/admin/test_metadata.py
+++ b/tests/unit/cli/admin/test_metadata.py
@@ -107,17 +107,20 @@ class TestMetadataUpdate:
             data = json.loads(f.read())
             root = Metadata.from_dict(data["metadata"]["root"])
 
-        for root_key_id in root.signed.roles["root"].keyids:
-            root_key = root.signed.keys[root_key_id]
-            # Only "Steven's key" is left which existed from the initial root
+        for root_id in root.signed.roles["root"].keyids:
+            root_key = root.signed.keys[root_id]
+            # Only "Steven's key" is left which existed from the initial root.
+            # For the rest of the keys there is no input and we expect them to
+            # have a default name.
             if root_key.unrecognized_fields.get("name") != "Steven's Key":
-                assert root_key.unrecognized_fields.get("name") is None
+                assert root_key.unrecognized_fields.get("name") == root_id[:7]
 
         online_roles = ["timestamp", "snapshot", "targets"]
         for role in online_roles:
             keyid = root.signed.roles[role].keyids[0]
             key = root.signed.keys[keyid]
-            assert key.unrecognized_fields.get("name") is None
+            # Make sure the online key name has been given a default value
+            assert key.unrecognized_fields.get("name") == keyid[:7]
 
     def test_metadata_update_no_root_changes(
         self, client, test_context, md_update_input


### PR DESCRIPTION
<!--- Thanks for taking the time to fill out this pull request! -->
<!--- Please fill in the fields below to submit a pull request. 
The more information provided, the better. -->


# Description
<!--- What is the PR about? -->

In this pr, I did some small refactorings such as:
- coloring password inputs
- adding one `get_key()` that is reused instead of having 3 implementations
- make sure that the question asking for key name input is the same everywhere

# Additional requirements
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [ ] I agree to follow this project's Code of Conduct