### PR TITLE
Add the choice of a key scheme as a requirement when describing a public key

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
   - id: isort
     args: [-l79, --profile, black, --check, --diff]
 - repo: https://github.com/psf/black
-  rev: '23.10.0'
+  rev: '23.10.1'
   hooks:
   - id: black
     args: [-l79, --check, --diff, .]

--- a/repository_service_tuf/cli/key/generate.py
+++ b/repository_service_tuf/cli/key/generate.py
@@ -45,11 +45,10 @@ def generate() -> None:
     """Generate cryptographic keys using the `securesystemslib` library"""
 
     key_type: str = prompt.Prompt.ask(
-        "\nChoose key type",
+        "\nChoose [green]key type[/]",
         choices=KeyType.get_all_members(),
         default=KeyType.KEY_TYPE_ED25519.value,
     )
-
     filename: str = prompt.Prompt.ask(
         "Enter the key's [green]filename[/]:",
         default=f"id_{key_type}",

--- a/repository_service_tuf/constants.py
+++ b/repository_service_tuf/constants.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 from enum import Enum
-from typing import List
+from typing import Dict, List
 
 from securesystemslib.interface import (  # type: ignore
     KEY_TYPE_ECDSA,
@@ -22,3 +22,13 @@ class KeyType(str, Enum):
     @classmethod
     def get_all_members(cls) -> List[str]:
         return [e.value for e in cls]
+
+
+# Those defaults are taken from scheme arg default at
+# import_KEY_TYPE_privatekey_from_file() functions at
+# securesystemslib.interface.py
+SCHEME_DEFAULTS: Dict[str, str] = {
+    KeyType.KEY_TYPE_ED25519.value: KEY_TYPE_ED25519,
+    KeyType.KEY_TYPE_ECDSA.value: "ecdsa-sha2-nistp256",
+    KeyType.KEY_TYPE_RSA.value: "rsassa-pss-sha256",
+}

--- a/repository_service_tuf/helpers/tuf.py
+++ b/repository_service_tuf/helpers/tuf.py
@@ -23,6 +23,7 @@ from securesystemslib.interface import (  # type: ignore
 )
 from securesystemslib.signer import Signer  # type: ignore
 from securesystemslib.signer import SSlibSigner  # type: ignore
+from securesystemslib.signer import KEY_FOR_TYPE_AND_SCHEME
 from securesystemslib.signer import SSlibKey as Key  # type: ignore
 from tuf.api.exceptions import UnsignedMetadataError
 from tuf.api.metadata import SPECIFICATION_VERSION, Metadata, Role, Root
@@ -427,6 +428,15 @@ class TUFManagement:
         return self.repository_metadata
 
 
+def get_supported_schemes_for_key_type(key_type: str) -> List[str]:
+    supported_schemes: List[str] = []
+    for info in KEY_FOR_TYPE_AND_SCHEME.keys():
+        if info[0] == key_type:
+            supported_schemes.append(info[1])
+
+    return supported_schemes
+
+
 def load_key(
     filepath: str, keytype: str, password: Optional[str], name: str
 ) -> RSTUFKey:
@@ -473,10 +483,12 @@ def print_key_table(rstuf_key: RSTUFKey) -> None:
     key_table = table.Table()
     key_table.add_column("Key ID", justify="center")
     key_table.add_column("Key Type", justify="center")
+    key_table.add_column("Key Scheme", justify="center")
     key_table.add_column("Public Key", justify="center")
     row_items = [
         rstuf_key.key["keyid"],
         rstuf_key.key["keytype"],
+        rstuf_key.key["scheme"],
         rstuf_key.key["keyval"]["public"],
     ]
 

--- a/tests/unit/cli/admin/test_ceremony.py
+++ b/tests/unit/cli/admin/test_ceremony.py
@@ -306,9 +306,45 @@ class TestCeremonyInteraction:
         # key and confirm the configuration
         input_step4 = [
             "n",  # Is the online key configuration correct? [y/n]
-            "rsa",  # Choose 1/1 ONLINE key type [ed25519/ecdsa/rsa]
+            "",  # Select the ONLINE`s key type [ed25519/ecdsa/rsa] (ed25519)
             "f7a6872f297634219a80141caa2ec9ae8802098b07b67963272603e36cc19fd8",  # Enter ONLINE`s key id  # noqa
             "9fe7ddccb75b977a041424a1fdc142e01be4abab918dc4c611fbfe4a3360a9a8",  # Enter ONLINE`s public key hash   # noqa
+            "",  # Give a name/tag to the key [Optional]
+            "y",  # Is the online key configuration correct? [y/n]
+            "y",  # Is the root configuration correct? [y/n]
+            "y",  # Is the targets configuration correct? [y/n]
+            "y",  # Is the snapshot configuration correct? [y/n]
+            "y",  # Is the timestamp configuration correct? [y/n]
+            "y",  # Is the bins configuration correct? [y/n]
+        ]
+
+        test_result = client.invoke(
+            ceremony.ceremony,
+            input="\n".join(
+                input_step1 + input_step2 + input_step3 + input_step4
+            ),
+            obj=test_context,
+        )
+
+        assert test_result.exit_code == 0, test_result.output
+        assert "Ceremony done. 🔐 🎉." in test_result.output
+        # passwords not shown in output
+        assert "strongPass" not in test_result.output
+
+    def test_ceremony_online_key_non_ed25519_key_type(
+        self, client, test_context, test_inputs, test_setup
+    ):
+        ceremony.setup = test_setup
+        input_step1, input_step2, input_step3, input_step4 = test_inputs
+
+        # overwrite the step 4
+        # Load RSA key with more than 1 scheme option.
+        input_step4 = [
+            "n",  # Is the online key configuration correct? [y/n]
+            "rsa",  # Choose 1/1 ONLINE key type [ed25519/ecdsa/rsa]
+            "rsassa-pss-sha256",  # Choose ONLINE`s key scheme [rsassa-pss-sha256] ([rsassa-pss-sha|rsa-pkcs1v15-sha][224, 256, 384, 512])  # noqa
+            "b1b4a183b603ad34e898ab7a3b4d138d5fab5bcd77f6a8abee49be17aeea302c",  # Enter ONLINE`s key id  # noqa
+            "-----BEGIN PUBLIC KEY-----\nMIIBojANBgkqhkiG9...\n-----END PUBLIC KEY-----",  # Enter ONLINE`s public key hash   # noqa
             "",  # [Optional] Give a name/tag to the key
             "y",  # Is the online key configuration correct? [y/n]
             "y",  # Is the root configuration correct? [y/n]

--- a/tests/unit/cli/admin/test_ceremony.py
+++ b/tests/unit/cli/admin/test_ceremony.py
@@ -307,8 +307,8 @@ class TestCeremonyInteraction:
         input_step4 = [
             "n",  # Is the online key configuration correct? [y/n]
             "rsa",  # Choose 1/1 ONLINE key type [ed25519/ecdsa/rsa]
-            "tests/files/key_storage/online-rsa.key",  # Enter 1/1 the ONLINE`s private key path  # noqa
-            "strongPass",  # Enter 1/1 the ONLINE`s private key password
+            "f7a6872f297634219a80141caa2ec9ae8802098b07b67963272603e36cc19fd8",  # Enter ONLINE`s key id  # noqa
+            "9fe7ddccb75b977a041424a1fdc142e01be4abab918dc4c611fbfe4a3360a9a8",  # Enter ONLINE`s public key hash   # noqa
             "",  # [Optional] Give a name/tag to the key
             "y",  # Is the online key configuration correct? [y/n]
             "y",  # Is the root configuration correct? [y/n]

--- a/tests/unit/cli/key/test_generate.py
+++ b/tests/unit/cli/key/test_generate.py
@@ -42,7 +42,7 @@ class TestGenerateInteraction:
 
         assert test_result.exit_code == 1
 
-    @pytest.mark.parametrize("key_type", KeyType.get_all_members() + ["test"])
+    @pytest.mark.parametrize("key_type", KeyType.get_all_members())
     def test_generate_types_generation(self, key_type, client) -> None:
         """
         Test that all `KeyType` enum members input choices call the appropriate
@@ -76,40 +76,25 @@ class TestGenerateInteraction:
             "rsa": "_generate_and_write_rsa_keypair",
         }
 
-        if key_type in KeyType.get_all_members():
-            with patch(
-                mock_file_path + mocked_functions[key_type],
-                return_value=None,
-            ) as mock_keypair:
-                test_result = client.invoke(
-                    generate.generate,
-                    input="\n".join(inputs),
-                    catch_exceptions=False,
-                )
-
-                mock_keypair.called_once()
-                assert test_result.exit_code == 0
-                assert generate.load_key.calls == [
-                    pretend.call(filename, key_type, password, "")
-                ]
-                assert "keyid" in test_result.output
-                assert "keytype" in test_result.output
-                assert "scheme" in test_result.output
-                assert "k_public" in test_result.output
-                assert "k_private" not in test_result.output
-
-        else:
+        with patch(
+            mock_file_path + mocked_functions[key_type],
+            return_value=None,
+        ) as mock_keypair:
             test_result = client.invoke(
                 generate.generate,
                 input="\n".join(inputs),
+                catch_exceptions=False,
             )
 
-            assert test_result.exit_code == 1
-            assert generate.load_key.calls == []
-            assert "keyid" not in test_result.output
-            assert "keytype" not in test_result.output
-            assert "scheme" not in test_result.output
-            assert "k_public" not in test_result.output
+            mock_keypair.called_once()
+            assert test_result.exit_code == 0
+            assert generate.load_key.calls == [
+                pretend.call(filename, key_type, password, "")
+            ]
+            assert "keyid" in test_result.output
+            assert "keytype" in test_result.output
+            assert "scheme" in test_result.output
+            assert "k_public" in test_result.output
             assert "k_private" not in test_result.output
 
     @pytest.mark.parametrize("filename", ["\n", "test-filename"])

--- a/tests/unit/cli/key/test_generate.py
+++ b/tests/unit/cli/key/test_generate.py
@@ -43,9 +43,7 @@ class TestGenerateInteraction:
         assert test_result.exit_code == 1
 
     @pytest.mark.parametrize("key_type", KeyType.get_all_members() + ["test"])
-    def test_generate_types_generation(
-        self, key_type, client, monkeypatch
-    ) -> None:
+    def test_generate_types_generation(self, key_type, client) -> None:
         """
         Test that all `KeyType` enum members input choices call the appropriate
         keypair generate function
@@ -56,7 +54,7 @@ class TestGenerateInteraction:
         inputs = [
             key_type,  # Choose key type [ed25519/ecdsa/rsa] (ed25519)
             filename,  # Enter the keys' filename ...
-            "y",  # Do you want to overwrite the existing 'test-filename' file?
+            "y",  # Do you want to overwrite the existing 'test-filename' file?  # noqa: E501
         ]
 
         generate._verify_password = pretend.call_recorder(lambda a: password)
@@ -65,6 +63,7 @@ class TestGenerateInteraction:
                 key={
                     "keyid": "keyid",
                     "keytype": "keytype",
+                    "scheme": "scheme",
                     "keyval": {"public": "k_public", "private": "private"},
                 }
             )
@@ -95,6 +94,7 @@ class TestGenerateInteraction:
                 ]
                 assert "keyid" in test_result.output
                 assert "keytype" in test_result.output
+                assert "scheme" in test_result.output
                 assert "k_public" in test_result.output
                 assert "k_private" not in test_result.output
 
@@ -108,6 +108,7 @@ class TestGenerateInteraction:
             assert generate.load_key.calls == []
             assert "keyid" not in test_result.output
             assert "keytype" not in test_result.output
+            assert "scheme" not in test_result.output
             assert "k_public" not in test_result.output
             assert "k_private" not in test_result.output
 
@@ -125,6 +126,7 @@ class TestGenerateInteraction:
             inputs = [
                 key_type,  # Choose key type [ed25519/ecdsa/rsa] (ed25519)
                 filename,  # Enter the keys' filename ...
+                "y",  # Do you want to overwrite the existing 'filename' file
             ]
 
             generate._verify_password = pretend.call_recorder(
@@ -134,6 +136,7 @@ class TestGenerateInteraction:
             test_result = client.invoke(
                 generate.generate,
                 input="\n".join(inputs),
+                catch_exceptions=False,
             )
 
             # the default option for the filename
@@ -175,6 +178,7 @@ class TestGenerateInteraction:
         test_result = client.invoke(
             generate.generate,
             input="\n".join(inputs),
+            catch_exceptions=False,
         )
 
         assert generate.os.path.isfile.calls == [pretend.call(filename)]  # type: ignore # noqa: E501

--- a/tests/unit/cli/key/test_generate.py
+++ b/tests/unit/cli/key/test_generate.py
@@ -56,7 +56,7 @@ class TestGenerateInteraction:
         inputs = [
             key_type,  # Choose key type [ed25519/ecdsa/rsa] (ed25519)
             filename,  # Enter the keys' filename ...
-            "n",  # Do you want to overwrite the existing 'test-filename' file?
+            "y",  # Do you want to overwrite the existing 'test-filename' file?
         ]
 
         generate._verify_password = pretend.call_recorder(lambda a: password)

--- a/tests/unit/cli/key/test_info.py
+++ b/tests/unit/cli/key/test_info.py
@@ -23,6 +23,7 @@ class TestKeyInfoInteraction:
                     key={
                         "keyid": "keyid",
                         "keytype": "keytype",
+                        "scheme": "scheme",
                         "keyval": {"public": "k_public", "private": "private"},
                     }
                 )
@@ -37,6 +38,7 @@ class TestKeyInfoInteraction:
         assert result.exit_code == 0, result.output
         assert "keyid" in result.output
         assert "keytype" in result.output
+        assert "scheme" in result.output
         assert "k_public" in result.output
         assert "k_private" not in result.output
         assert info.load_key.calls == [


### PR DESCRIPTION
# Description
<!--- What is the PR about? -->

When describing a public key during bootstrap the administrators will
now have to describe the public key scheme as well.

For that reason, I have also updated the "rstuf key info" command and
now it gives information about key scheme as well.

Also, fixed test answers to public key questions.

PS: I have added a new test `test_ceremony_online_key_non_ed25519_key_type`
which is described strangely by git as a change of an existing case instead.
I recommend reading both tests to understand what I did.

**Important**: This pr is a requirement for https://github.com/repository-service-tuf/repository-service-tuf-worker/issues


<!--- Please reference the issue(s) this PR fixes. -->
Fixes #428


# Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [ ] I agree to follow this project's Code of Conduct