### PR TITLE
Add testing duration improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,25 @@ jobs:
     - name: Test Build binary wheel and source tarball
       run: python3 -m build --sdist --wheel --outdir dist/ .
 
+    - name: Restore mypy cache
+      id: cache-mypy-restore
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          .mypy_cache
+        key: ${{ runner.os }}-py${{ matrix.python-versions }}-mypy-${{ hashFiles('**/.mypy_cache') }}
+
     - name: Run Python tests
-      run: make tests
+      run: |
+        make tests
+
+    - name: Save mypy cache
+      id: cache-mypy-save
+      uses: actions/cache/save@v3
+      with:
+        path: |
+          .mypy_cache
+        key: ${{ runner.os }}-py${{ matrix.python-versions }}-mypy-${{ hashFiles('**/.mypy_cache') }}
 
     - name: Codecov
       uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d

--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,7 @@ dynaconf = {extras = ["yaml"], version = "*"}
 isort = "*"
 sqlalchemy = "*"
 psycopg2 = "*"
+pytest-xdist = "*"
 
 [dev-packages]
 black = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "202a5d0866da24c1a8d879d6ed8295f6a9f66bce5d36300823d47cd551ed5728"
+            "sha256": "99760730cbd826250f64828302f19883707a0a7365ca1f6f34526bb639e9eadb"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -22,7 +22,6 @@
                 "sha256:f65100404e2d35225402852da2e3d32e0390ac25a1245fff1b40178340ab3875"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7' and python_version < '4.0'",
             "version": "==0.1.1"
         },
         "certifi": {
@@ -193,7 +192,6 @@
                 "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==8.1.7"
         },
         "cryptography": {
@@ -232,8 +230,24 @@
                 "sha256:8a37ba3b16df64cb1db383eaad9c733aece218413be0fad5d785f7a907612106",
                 "sha256:df4af8d0f3b068cc6419ceceaae572070a6b8fec38fa51a1f5eb8ea4883e53de"
             ],
-            "markers": "python_version >= '3.8'",
+            "index": "pypi",
             "version": "==3.2.3"
+        },
+        "exceptiongroup": {
+            "hashes": [
+                "sha256:097acd85d473d75af5bb98e41b61ff7fe35efe6675e4f9370ec6ec5126d160e9",
+                "sha256:343280667a4585d195ca1cf9cef84a4e178c4b6cf2274caef9859782b567d5e3"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==1.1.3"
+        },
+        "execnet": {
+            "hashes": [
+                "sha256:88256416ae766bc9e8895c76a87928c0012183da3cc4fc18016e6f050e025f41",
+                "sha256:cc59bc4423742fd71ad227122eb0dd44db51efb3dc4095b45ac9a08c770096af"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.2"
         },
         "greenlet": {
             "hashes": [
@@ -306,13 +320,20 @@
             "markers": "python_version >= '3.5'",
             "version": "==3.4"
         },
+        "iniconfig": {
+            "hashes": [
+                "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3",
+                "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.0"
+        },
         "isort": {
             "hashes": [
                 "sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504",
                 "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"
             ],
             "index": "pypi",
-            "markers": "python_full_version >= '3.8.0'",
             "version": "==5.12.0"
         },
         "markdown-it-py": {
@@ -331,6 +352,22 @@
             "markers": "python_version >= '3.7'",
             "version": "==0.1.2"
         },
+        "packaging": {
+            "hashes": [
+                "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5",
+                "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==23.2"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:cf61ae8f126ac6f7c451172cf30e3e43d3ca77615509771b3a984a0730651e12",
+                "sha256:d89c696a773f8bd377d18e5ecda92b7a3793cbe66c87060a6fb58c7b6e1061f7"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.3.0"
+        },
         "psycopg2": {
             "hashes": [
                 "sha256:121081ea2e76729acfb0673ff33755e8703d45e926e416cb59bae3a86c6a4981",
@@ -346,7 +383,6 @@
                 "sha256:ff432630e510709564c01dafdbe996cb552e0b9f3f065eb89bdce5bd31fabf4c"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==2.9.9"
         },
         "pycparser": {
@@ -377,8 +413,24 @@
                 "sha256:a422368fc821589c228f4c49438a368831cb5bbc0eab5ebe1d7fac9dded6567b",
                 "sha256:e46dae94e34b085175f8abb3b0aaa7da40767865ac82c928eeb9e57e1ea8a543"
             ],
-            "markers": "python_version >= '3.6'",
+            "index": "pypi",
             "version": "==1.5.0"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:0d009c083ea859a71b76adf7c1d502e4bc170b80a8ef002da5806527b9591fac",
+                "sha256:d989d136982de4e3b29dabcc838ad581c64e8ed52c11fbe86ddebd9da0818cd5"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==7.4.3"
+        },
+        "pytest-xdist": {
+            "hashes": [
+                "sha256:d5ee0520eb1b7bcca50a60a518ab7a7707992812c578198f8b44fdfac78e8c93",
+                "sha256:ff9daa7793569e6a68544850fd3927cd257cc03a7ef76c95e86915355e82b5f2"
+            ],
+            "index": "pypi",
+            "version": "==3.3.1"
         },
         "requests": {
             "hashes": [
@@ -386,7 +438,6 @@
                 "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==2.31.0"
         },
         "rich": {
@@ -395,7 +446,6 @@
                 "sha256:5c14d22737e6d5084ef4771b62d5d4363165b403455a30a1c8ca39dc7b644bef"
             ],
             "index": "pypi",
-            "markers": "python_full_version >= '3.7.0'",
             "version": "==13.6.0"
         },
         "rich-click": {
@@ -404,7 +454,6 @@
                 "sha256:ab34e5d9f7733c4e6072f4de79eb3b35ac9ae78e692ea8a543f3b2828b30fee4"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==1.7.0"
         },
         "ruamel.yaml": {
@@ -478,7 +527,7 @@
                 "sha256:9e6b9abe36a511d4f52c759069db8f6f650362ba82d6efc7bc7466a458b3f499",
                 "sha256:a27e519247576f2a77b97fb03267d8eeb88eba715d12da64109e845616f919c6"
             ],
-            "markers": "python_version ~= '3.7'",
+            "index": "pypi",
             "version": "==0.28.0"
         },
         "sqlalchemy": {
@@ -534,8 +583,15 @@
                 "sha256:f776c2c30f0e5f4db45c3ee11a5f2a8d9de68e81eb73ec4237de1e32e04ae81c"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==2.0.22"
+        },
+        "tomli": {
+            "hashes": [
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==2.0.1"
         },
         "tuf": {
             "hashes": [
@@ -543,7 +599,6 @@
                 "sha256:e8fb94cb38f472530d591c59e87f22698355a673231f5bf50d7d1da4842c0007"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==3.0.0"
         },
         "typing-extensions": {
@@ -586,7 +641,6 @@
                 "sha256:bdfc739baa03b880c2d15d0431b31c658ffc348e907fe197e54e0389dd59e11e"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==1.7.5"
         },
         "black": {
@@ -611,7 +665,6 @@
                 "sha256:ec3f8e6234c4e46ff9e16d9ae96f4ef69fa328bb4ad08198c8cee45bb1f08c69"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==23.10.1"
         },
         "build": {
@@ -620,7 +673,6 @@
                 "sha256:589bf99a67df7c9cf07ec0ac0e5e2ea5d4b37ac63301c4986d1acb126aa83f8f"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==1.0.3"
         },
         "cachetools": {
@@ -757,7 +809,6 @@
                 "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==8.1.7"
         },
         "colorama": {
@@ -824,7 +875,6 @@
                 "sha256:fe494faa90ce6381770746077243231e0b83ff3f17069d748f645617cefe19d4"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==7.3.2"
         },
         "distlib": {
@@ -860,11 +910,11 @@
         },
         "filelock": {
             "hashes": [
-                "sha256:08c21d87ded6e2b9da6728c3dff51baf1dcecf973b768ef35bcbc3447edb9ad4",
-                "sha256:2e6f249f1f3654291606e046b09f1fd5eac39b360664c27f5aad072012f8bcbd"
+                "sha256:63c6052c82a1a24c873a549fbd39a26982e8f35a3016da231ead11a5be9dad44",
+                "sha256:a552f4fde758f4eab33191e9548f671970f8b06d436d31388c9aa1e5861a710f"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.12.4"
+            "version": "==3.13.0"
         },
         "flake8": {
             "hashes": [
@@ -872,7 +922,6 @@
                 "sha256:ffdfce58ea94c6580c77888a86506937f9a1a227dfcd15f245d694ae20a6b6e5"
             ],
             "index": "pypi",
-            "markers": "python_full_version >= '3.8.1'",
             "version": "==6.1.0"
         },
         "gitdb": {
@@ -945,7 +994,6 @@
                 "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"
             ],
             "index": "pypi",
-            "markers": "python_full_version >= '3.8.0'",
             "version": "==5.12.0"
         },
         "jinja2": {
@@ -1077,7 +1125,6 @@
                 "sha256:eb4f18589d196a4cbe5290b435d135dee96567e07c2b2d43b5c4621b6501531a"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==1.6.1"
         },
         "mypy-extensions": {
@@ -1101,7 +1148,7 @@
                 "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5",
                 "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"
             ],
-            "markers": "python_version >= '3.1'",
+            "markers": "python_version >= '3.7'",
             "version": "==23.2"
         },
         "pathspec": {
@@ -1126,7 +1173,6 @@
                 "sha256:55eb67bb6171d37447e82213be585b75fe2b12b359e993773aca4de9247a052b"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==23.3.1"
         },
         "platformdirs": {
@@ -1142,7 +1188,7 @@
                 "sha256:cf61ae8f126ac6f7c451172cf30e3e43d3ca77615509771b3a984a0730651e12",
                 "sha256:d89c696a773f8bd377d18e5ecda92b7a3793cbe66c87060a6fb58c7b6e1061f7"
             ],
-            "markers": "python_version >= '3.1'",
+            "markers": "python_version >= '3.8'",
             "version": "==1.3.0"
         },
         "pre-commit": {
@@ -1151,7 +1197,6 @@
                 "sha256:841dc9aef25daba9a0238cd27984041fa0467b4199fc4852e27950664919f660"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==3.5.0"
         },
         "pretend": {
@@ -1207,7 +1252,6 @@
                 "sha256:0d009c083ea859a71b76adf7c1d502e4bc170b80a8ef002da5806527b9591fac",
                 "sha256:d989d136982de4e3b29dabcc838ad581c64e8ed52c11fbe86ddebd9da0818cd5"
             ],
-            "index": "pypi",
             "markers": "python_version >= '3.7'",
             "version": "==7.4.3"
         },
@@ -1273,7 +1317,6 @@
                 "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==2.31.0"
         },
         "rich": {
@@ -1282,7 +1325,6 @@
                 "sha256:5c14d22737e6d5084ef4771b62d5d4363165b403455a30a1c8ca39dc7b644bef"
             ],
             "index": "pypi",
-            "markers": "python_full_version >= '3.7.0'",
             "version": "==13.6.0"
         },
         "setuptools": {
@@ -1314,7 +1356,6 @@
                 "sha256:9a5160e1ea90688d5963ba09a2dcd8bdd526620edbb65c328728f1b2228d5ab5"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==7.2.6"
         },
         "sphinx-rtd-theme": {
@@ -1323,7 +1364,6 @@
                 "sha256:590b030c7abb9cf038ec053b95e5380b5c70d61591eb0b552063fbe7c41f0931"
             ],
             "index": "pypi",
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==1.3.0"
         },
         "sphinxcontrib-applehelp": {
@@ -1332,7 +1372,6 @@
                 "sha256:39fdc8d762d33b01a7d8f026a3b7d71563ea3b72787d5f00ad8465bd9d6dfbfa"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==1.0.7"
         },
         "sphinxcontrib-devhelp": {
@@ -1341,7 +1380,6 @@
                 "sha256:fe8009aed765188f08fcaadbb3ea0d90ce8ae2d76710b7e29ea7d047177dae2f"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==1.0.5"
         },
         "sphinxcontrib-htmlhelp": {
@@ -1350,7 +1388,6 @@
                 "sha256:8001661c077a73c29beaf4a79968d0726103c5605e27db92b9ebed8bab1359e9"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==2.0.4"
         },
         "sphinxcontrib-jquery": {
@@ -1367,7 +1404,6 @@
                 "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.5'",
             "version": "==1.0.1"
         },
         "sphinxcontrib-plantuml": {
@@ -1383,7 +1419,6 @@
                 "sha256:bf76886ee7470b934e363da7a954ea2825650013d367728588732c7350f49ea4"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==1.0.6"
         },
         "sphinxcontrib-serializinghtml": {
@@ -1392,7 +1427,6 @@
                 "sha256:9b36e503703ff04f20e9675771df105e58aa029cfcbc23b8ed716019b7416ae1"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==1.1.9"
         },
         "stevedore": {
@@ -1408,7 +1442,7 @@
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
                 "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version >= '3.1'",
+            "markers": "python_version < '3.11'",
             "version": "==2.0.1"
         },
         "tox": {
@@ -1417,7 +1451,6 @@
                 "sha256:599af5e5bb0cad0148ac1558a0b66f8fff219ef88363483b8d92a81e4246f28f"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==4.11.3"
         },
         "types-requests": {
@@ -1426,7 +1459,6 @@
                 "sha256:dc5852a76f1eaf60eafa81a2e50aefa3d1f015c34cf0cba130930866b1b22a92"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==2.31.0.10"
         },
         "typing-extensions": {

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,89 +1,91 @@
 -i https://pypi.org/simple
-alabaster==0.7.13; python_version >= '3.6'
-babel==2.13.1; python_version >= '3.7'
-bandit==1.7.5; python_version >= '3.7'
-black==23.10.1; python_version >= '3.8'
-build==1.0.3; python_version >= '3.7'
-cachetools==5.3.2; python_version >= '3.7'
-certifi==2023.7.22; python_version >= '3.6'
-cfgv==3.4.0; python_version >= '3.8'
-chardet==5.2.0; python_version >= '3.7'
-charset-normalizer==3.3.1; python_full_version >= '3.7.0'
-click==8.1.7; python_version >= '3.7'
-colorama==0.4.6; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
-coverage==7.3.2; python_version >= '3.8'
+alabaster==0.7.13 ; python_version >= '3.6'
+babel==2.13.1 ; python_version >= '3.7'
+bandit==1.7.5
+black==23.10.1
+build==1.0.3
+cachetools==5.3.2 ; python_version >= '3.7'
+certifi==2023.7.22 ; python_version >= '3.6'
+cfgv==3.4.0 ; python_version >= '3.8'
+chardet==5.2.0 ; python_version >= '3.7'
+charset-normalizer==3.3.1 ; python_full_version >= '3.7.0'
+click==8.1.7
+colorama==0.4.6 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
+coverage==7.3.2
 distlib==0.3.7
-docutils==0.18.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-editables==0.5; python_version >= '3.1'
-exceptiongroup==1.1.3; python_version < '3.11'
-filelock==3.12.4; python_version >= '3.8'
-flake8==6.1.0; python_full_version >= '3.8.1'
-gitdb==4.0.11; python_version >= '3.7'
-gitpython==3.1.40; python_version >= '3.7'
+docutils==0.18.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+editables==0.5 ; python_version >= '3.1'
+exceptiongroup==1.1.3 ; python_version < '3.11'
+filelock==3.13.0 ; python_version >= '3.8'
+flake8==6.1.0
+gitdb==4.0.11 ; python_version >= '3.7'
+gitpython==3.1.40 ; python_version >= '3.7'
 hatchling==0.22.0
-identify==2.5.30; python_version >= '3.8'
-idna==3.4; python_version >= '3.5'
-imagesize==1.4.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-importlib-metadata==6.8.0; python_version < '3.10'
-iniconfig==2.0.0; python_version >= '3.7'
-isort==5.12.0; python_full_version >= '3.8.0'
-jinja2==3.1.2; python_version >= '3.7'
-markdown-it-py==3.0.0; python_version >= '3.8'
-markupsafe==2.1.3; python_version >= '3.7'
-mccabe==0.7.0; python_version >= '3.6'
-mdurl==0.1.2; python_version >= '3.7'
-mypy==1.6.1; python_version >= '3.8'
-mypy-extensions==1.0.0; python_version >= '3.5'
-nodeenv==1.8.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
-packaging==23.2; python_version >= '3.1'
-pathspec==0.11.2; python_version >= '3.7'
-pbr==5.11.1; python_version >= '2.6'
-pip==23.3.1; python_version >= '3.7'
-platformdirs==3.11.0; python_version >= '3.7'
-pluggy==1.3.0; python_version >= '3.1'
-pre-commit==3.5.0; python_version >= '3.8'
+identify==2.5.30 ; python_version >= '3.8'
+idna==3.4 ; python_version >= '3.5'
+imagesize==1.4.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+importlib-metadata==6.8.0 ; python_version < '3.10'
+iniconfig==2.0.0 ; python_version >= '3.7'
+isort==5.12.0
+jinja2==3.1.2 ; python_version >= '3.7'
+markdown-it-py==3.0.0 ; python_version >= '3.8'
+markupsafe==2.1.3 ; python_version >= '3.7'
+mccabe==0.7.0 ; python_version >= '3.6'
+mdurl==0.1.2 ; python_version >= '3.7'
+mypy==1.6.1
+mypy-extensions==1.0.0 ; python_version >= '3.5'
+nodeenv==1.8.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
+packaging==23.2 ; python_version >= '3.7'
+pathspec==0.11.2 ; python_version >= '3.7'
+pbr==5.11.1 ; python_version >= '2.6'
+pip==23.3.1
+platformdirs==3.11.0 ; python_version >= '3.7'
+pluggy==1.3.0 ; python_version >= '3.8'
+pre-commit==3.5.0
 pretend==1.0.9
-pycodestyle==2.11.1; python_version >= '3.8'
-pyflakes==3.1.0; python_version >= '3.8'
-pygments==2.16.1; python_version >= '3.7'
-pyproject-api==1.6.1; python_version >= '3.8'
-pyproject-hooks==1.0.0; python_version >= '3.7'
-pytest==7.4.3; python_version >= '3.7'
-pyyaml==6.0.1; python_version >= '3.6'
-requests==2.31.0; python_version >= '3.7'
-rich==13.6.0; python_full_version >= '3.7.0'
-setuptools==68.2.2; python_version >= '3.8'
-smmap==5.0.1; python_version >= '3.7'
+pycodestyle==2.11.1 ; python_version >= '3.8'
+pyflakes==3.1.0 ; python_version >= '3.8'
+pygments==2.16.1 ; python_version >= '3.7'
+pyproject-api==1.6.1 ; python_version >= '3.8'
+pyproject-hooks==1.0.0 ; python_version >= '3.7'
+pytest==7.4.3 ; python_version >= '3.7'
+pyyaml==6.0.1 ; python_version >= '3.6'
+requests==2.31.0
+rich==13.6.0
+setuptools==68.2.2 ; python_version >= '3.8'
+smmap==5.0.1 ; python_version >= '3.7'
 snowballstemmer==2.2.0
-sphinx==7.2.6; python_version >= '3.9'
-sphinx-rtd-theme==1.3.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
-sphinxcontrib-applehelp==1.0.7; python_version >= '3.9'
-sphinxcontrib-devhelp==1.0.5; python_version >= '3.9'
-sphinxcontrib-htmlhelp==2.0.4; python_version >= '3.9'
-sphinxcontrib-jquery==4.1; python_version >= '2.7'
-sphinxcontrib-jsmath==1.0.1; python_version >= '3.5'
+sphinx==7.2.6
+sphinx-rtd-theme==1.3.0
+sphinxcontrib-applehelp==1.0.7
+sphinxcontrib-devhelp==1.0.5
+sphinxcontrib-htmlhelp==2.0.4
+sphinxcontrib-jquery==4.1 ; python_version >= '2.7'
+sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-plantuml==0.26
-sphinxcontrib-qthelp==1.0.6; python_version >= '3.9'
-sphinxcontrib-serializinghtml==1.1.9; python_version >= '3.9'
-stevedore==5.1.0; python_version >= '3.8'
-tomli==2.0.1; python_version >= '3.1'
-tox==4.11.3; python_version >= '3.8'
-types-requests==2.31.0.10; python_version >= '3.7'
-typing-extensions==4.8.0; python_version >= '3.8'
-urllib3==2.0.7; python_version >= '3.7'
-virtualenv==20.24.6; python_version >= '3.7'
-zipp==3.17.0; python_version >= '3.8'
-auto-click-auto==0.1.1; python_version >= '3.7' and python_version < '4.0'
-cffi==1.16.0; python_version >= '3.8'
+sphinxcontrib-qthelp==1.0.6
+sphinxcontrib-serializinghtml==1.1.9
+stevedore==5.1.0 ; python_version >= '3.8'
+tomli==2.0.1 ; python_version < '3.11'
+tox==4.11.3
+types-requests==2.31.0.10
+typing-extensions==4.8.0 ; python_version >= '3.8'
+urllib3==2.0.7 ; python_version >= '3.7'
+virtualenv==20.24.6 ; python_version >= '3.7'
+zipp==3.17.0 ; python_version >= '3.8'
+auto-click-auto==0.1.1
+cffi==1.16.0 ; python_version >= '3.8'
 cryptography==41.0.5
-dynaconf[yaml]==3.2.3; python_version >= '3.8'
-greenlet==3.0.1; platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))
-psycopg2==2.9.9; python_version >= '3.7'
+dynaconf[yaml]==3.2.3
+execnet==2.0.2 ; python_version >= '3.7'
+greenlet==3.0.1 ; platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))
+psycopg2==2.9.9
 pycparser==2.21
-pynacl==1.5.0; python_version >= '3.6'
-rich-click==1.7.0; python_version >= '3.7'
+pynacl==1.5.0
+pytest-xdist==3.3.1
+rich-click==1.7.0
 ruamel.yaml==0.18.2
-ruamel.yaml.clib==0.2.8; python_version < '3.13' and platform_python_implementation == 'CPython'
-securesystemslib[crypto]==0.28.0; python_version ~= '3.7'
-sqlalchemy==2.0.22; python_version >= '3.7'
-tuf==3.0.0; python_version >= '3.7'
+ruamel.yaml.clib==0.2.8 ; python_version < '3.13' and platform_python_implementation == 'CPython'
+securesystemslib[crypto]==0.28.0
+sqlalchemy==2.0.22
+tuf==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,27 +1,35 @@
 -i https://pypi.org/simple
-auto-click-auto==0.1.1; python_version >= '3.7' and python_version < '4.0'
-certifi==2023.7.22; python_version >= '3.6'
-cffi==1.16.0; python_version >= '3.8'
-charset-normalizer==3.3.1; python_full_version >= '3.7.0'
-click==8.1.7; python_version >= '3.7'
+auto-click-auto==0.1.1
+certifi==2023.7.22 ; python_version >= '3.6'
+cffi==1.16.0 ; python_version >= '3.8'
+charset-normalizer==3.3.1 ; python_full_version >= '3.7.0'
+click==8.1.7
 cryptography==41.0.5
-dynaconf[yaml]==3.2.3; python_version >= '3.8'
-greenlet==3.0.1; platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))
-idna==3.4; python_version >= '3.5'
-isort==5.12.0; python_full_version >= '3.8.0'
-markdown-it-py==3.0.0; python_version >= '3.8'
-mdurl==0.1.2; python_version >= '3.7'
-psycopg2==2.9.9; python_version >= '3.7'
+dynaconf[yaml]==3.2.3
+exceptiongroup==1.1.3 ; python_version < '3.11'
+execnet==2.0.2 ; python_version >= '3.7'
+greenlet==3.0.1 ; platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))
+idna==3.4 ; python_version >= '3.5'
+iniconfig==2.0.0 ; python_version >= '3.7'
+isort==5.12.0
+markdown-it-py==3.0.0 ; python_version >= '3.8'
+mdurl==0.1.2 ; python_version >= '3.7'
+packaging==23.2 ; python_version >= '3.7'
+pluggy==1.3.0 ; python_version >= '3.8'
+psycopg2==2.9.9
 pycparser==2.21
-pygments==2.16.1; python_version >= '3.7'
-pynacl==1.5.0; python_version >= '3.6'
-requests==2.31.0; python_version >= '3.7'
-rich==13.6.0; python_full_version >= '3.7.0'
-rich-click==1.7.0; python_version >= '3.7'
+pygments==2.16.1 ; python_version >= '3.7'
+pynacl==1.5.0
+pytest==7.4.3 ; python_version >= '3.7'
+pytest-xdist==3.3.1
+requests==2.31.0
+rich==13.6.0
+rich-click==1.7.0
 ruamel.yaml==0.18.2
-ruamel.yaml.clib==0.2.8; python_version < '3.13' and platform_python_implementation == 'CPython'
-securesystemslib[crypto]==0.28.0; python_version ~= '3.7'
-sqlalchemy==2.0.22; python_version >= '3.7'
-tuf==3.0.0; python_version >= '3.7'
-typing-extensions==4.8.0; python_version >= '3.8'
-urllib3==2.0.7; python_version >= '3.7'
+ruamel.yaml.clib==0.2.8 ; python_version < '3.13' and platform_python_implementation == 'CPython'
+securesystemslib[crypto]==0.28.0
+sqlalchemy==2.0.22
+tomli==2.0.1 ; python_version < '3.11'
+tuf==3.0.0
+typing-extensions==4.8.0 ; python_version >= '3.8'
+urllib3==2.0.7 ; python_version >= '3.7'

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ commands =
 [testenv:test]
 allowlist_externals = coverage
 commands =
-    coverage run --omit='tests/*' -m pytest -vv tests/
+    coverage run --omit='tests/*' -m pytest -n auto -vv tests/
     coverage xml -i
     coverage report
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ commands =
     pre-commit run bandit --all-files --show-diff-on-failure
 
 [testenv:typing]
+setenv =
+    MYPY_CACHE_DIR = {toxinidir}/.mypy_cache
 commands =
     # Exclude tests for now as mocking and using pretend often leads to many
     # mypy warnings.

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,8 @@ deps = -r{toxinidir}/requirements.txt
 
 [testenv:lint]
 deps = pre-commit
+setenv =
+    BLACK_CACHE_DIR = ~/.cache/black/
 commands =
     pre-commit run flake8 --all-files --show-diff-on-failure
     pre-commit run isort --all-files --show-diff-on-failure


### PR DESCRIPTION
<!--- Thanks for taking the time to fill out this pull request! -->
<!--- Please fill in the fields below to submit a pull request. 
The more information provided, the better. -->

I experimented with a couple of improvements on our CI, that would make some things faster for our GH actions, but also for when we run tests on our local environments.

I added distributed runs to testing and caching of `mypy`. I have noticed ~25% decrease from the initial CI workflow duration (from about 4 mins to around 3 mins).

As the codebase grows the improvement might be even more useful. Additionally, we can apply these changes and check how much they help with the other repos under the RSTUF umbrella.

# Description
<!--- What is the PR about? -->


<!--- Please reference the issue(s) this PR fixes. -->


# Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct