### PR TITLE
Fix bugs in `artifact add` and improve UX

### DIFF
--- a/repository_service_tuf/helpers/cli.py
+++ b/repository_service_tuf/helpers/cli.py
@@ -70,7 +70,7 @@ def calculate_blake2b_256(filepath: str) -> str:
 
 
 def create_artifact_payload_from_filepath(
-    filepath: str, path: str
+    filepath: str, path: Optional[str]
 ) -> Dict[str, Any]:
     """
     Create the payload for the API request of `POST api/v1/artifacts/`.
@@ -83,6 +83,11 @@ def create_artifact_payload_from_filepath(
     length: int = os.path.getsize(filepath)
     blake2b_256_hash: str = calculate_blake2b_256(filepath)
 
+    if path:
+        payload_path = f"{path.rstrip('/')}/{filepath.split('/')[-1]}"
+    else:
+        payload_path = f"{filepath.split('/')[-1]}"
+
     payload = AddPayload(
         targets=[
             Targets(
@@ -93,7 +98,7 @@ def create_artifact_payload_from_filepath(
                     },
                     custom=None,
                 ),
-                path=f"{path.rstrip('/')}/{filepath.split('/')[-1]}",
+                path=payload_path,
             )
         ]
     )

--- a/tests/unit/cli/artifact/test_add.py
+++ b/tests/unit/cli/artifact/test_add.py
@@ -26,9 +26,6 @@ class TestAddArtifactInteraction:
             "fake-server",
         ]
 
-        add.create_artifact_payload_from_filepath = pretend.call_recorder(
-            lambda *a, **kw: {"k": "v"}
-        )
         add.send_payload = pretend.call_recorder(lambda *a, **kw: "123")
 
         with client.isolated_filesystem():
@@ -41,15 +38,77 @@ class TestAddArtifactInteraction:
         assert "Successfully submitted task" in result.output
         assert "RSTUF task ID" in result.output
 
-        assert add.create_artifact_payload_from_filepath.calls == [
-            pretend.call(filepath=artifact_path, path=path)
+        assert add.send_payload.calls == [
+            pretend.call(
+                settings=test_context["settings"],
+                url=URL.ARTIFACTS.value,
+                payload={
+                    "targets": [
+                        {
+                            "info": {
+                                "length": 14,
+                                "hashes": {
+                                    "blake2b-256": "5b23eadf78d64e16f4ecf121e6631c68fa8eb64fcd5a0762fd36ef37f61369e9"  # noqa
+                                },
+                                "custom": None,
+                            },
+                            "path": f"{path}/{artifact_path}",
+                        }
+                    ],
+                    "add_task_id_to_custom": False,
+                    "publish_targets": True,
+                },
+                expected_msg="New Artifact(s) successfully submitted.",
+                command_name="Artifact Addition",
+            )
         ]
+
+    def test_without_path(self, client, test_context):
+        """
+        Test that the add artifact command works as expected given the
+        expected arguments/options in the CLI.
+        """
+
+        artifact_path = "dummy-artifact"
+
+        input = [
+            artifact_path,  # artifact filepath
+            "--api-server",
+            "fake-server",
+        ]
+
+        add.send_payload = pretend.call_recorder(lambda *a, **kw: "123")
+
+        with client.isolated_filesystem():
+            with open(artifact_path, "w") as f:
+                f.write("Dummy Artifact")
+
+            result = client.invoke(add.add, input, obj=test_context)
+
+        assert result.exit_code == 0, result.output
+        assert "Successfully submitted task" in result.output
+        assert "RSTUF task ID" in result.output
 
         assert add.send_payload.calls == [
             pretend.call(
                 settings=test_context["settings"],
                 url=URL.ARTIFACTS.value,
-                payload={"k": "v"},
+                payload={
+                    "targets": [
+                        {
+                            "info": {
+                                "length": 14,
+                                "hashes": {
+                                    "blake2b-256": "5b23eadf78d64e16f4ecf121e6631c68fa8eb64fcd5a0762fd36ef37f61369e9"  # noqa
+                                },
+                                "custom": None,
+                            },
+                            "path": artifact_path,
+                        }
+                    ],
+                    "add_task_id_to_custom": False,
+                    "publish_targets": True,
+                },
                 expected_msg="New Artifact(s) successfully submitted.",
                 command_name="Artifact Addition",
             )


### PR DESCRIPTION
# Description
<!--- What is the PR about? -->

- Fix bug related the giving the RSTUF API Server (``--api-server``)
- Makes the user experience with ``--path`` and `filepaht` simpler and the output, see the cases below


Using a `rstuf.yaml`

```shell
> rstuf -c rstuf.yaml artifact add ~/tuf_metadata.tar
Artifact Addition status: ACCEPTED (94c234877b124bc5a747a9c4e0cb4761)
Successfully submitted task with a payload of:
{
  "targets": [
    {
      "info": {
        "length": 106956800,
        "hashes": {
          "blake2b-256": "597b97e43e445ecd06dfb8436b19e2ae6cfa137dd66523b9a022989355bde3dc"
        },
        "custom": null
      },
      "path": "tuf_metadata.tar"
    }
  ],
  "add_task_id_to_custom": false,
  "publish_targets": true
}

RSTUF task ID (use to check its status) is: 94c234877b124bc5a747a9c4e0cb4761
```

Using the `--path` and `--api-server`

```shell
> rstuf artifact add ~/tuf_metadata.tar --path tuf/files/ --api-server http://localhost
Artifact Addition status: ACCEPTED (1402d4b980794de98c0f7f99d0787cad)
Successfully submitted task with a payload of:
{
  "targets": [
    {
      "info": {
        "length": 106956800,
        "hashes": {
          "blake2b-256": "597b97e43e445ecd06dfb8436b19e2ae6cfa137dd66523b9a022989355bde3dc"
        },
        "custom": null
      },
      "path": "tuf/files/tuf_metadata.tar"
    }
  ],
  "add_task_id_to_custom": false,
  "publish_targets": true
}

RSTUF task ID (use to check its status) is: 1402d4b980794de98c0f7f99d0787cad
```
<!--- Please reference the issue(s) this PR fixes. -->
Fixes #(issue)


# Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct