### PR TITLE
Make autocompletion activation a command

### DIFF
--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -25,6 +25,7 @@ Using pip:
     ╭─ Options ────────────────────────────────────────────────────────────────────────────────╮
     │ --config   -c  TEXT  Repository Service for TUF config file. [default: $HOME/.rstuf.yml] │
     │ --version            Show the version and exit.                                          │
+    │ --autocomplete       Enable tab autocompletion and exit.                                 │
     │ --help     -h        Show this message and exit.                                         │
     ╰──────────────────────────────────────────────────────────────────────────────────────────╯
     ╭─ Commands ───────────────────────────────────────────────────────────╮

--- a/repository_service_tuf/__version__.py
+++ b/repository_service_tuf/__version__.py
@@ -3,6 +3,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-version = "0.8.3b1"
+version = "0.8.4b1"
 copyright = "Copyright (c) 2024 Repository Service for TUF Contributors"
 author = "Kairo de Araujo"

--- a/repository_service_tuf/cli/__init__.py
+++ b/repository_service_tuf/cli/__init__.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Optional
 
 import rich_click as click  # type: ignore
-from auto_click_auto import enable_click_shell_completion
+from auto_click_auto import enable_click_shell_completion_option
 from auto_click_auto.constants import ShellType
 from click import Context
 from rich.console import Console
@@ -35,6 +35,11 @@ try:
 except FileNotFoundError:  # pragma: no cover the tests will fail in general
     pass
 
+# Enable tab completion for all available supported shells
+supported_shell_types = {
+    ShellType(shell) for shell in ShellType.get_all_values()
+}
+
 
 @click.group(  # type: ignore
     context_settings={"help_option_names": ["-h", "--help"]}
@@ -50,6 +55,9 @@ except FileNotFoundError:  # pragma: no cover the tests will fail in general
 )
 # adds the --version parameter
 @click.version_option(prog_name=prog_name, version=version)
+@enable_click_shell_completion_option(
+    program_name=prog_name, shells=supported_shell_types
+)
 @click.pass_context
 def rstuf(
     context: Context,
@@ -70,11 +78,3 @@ for _, name, _ in pkgutil.walk_packages(  # type: ignore
     __path__, prefix=__name__ + "."
 ):
     importlib.import_module(name)
-
-# Enable tab completion for all available supported shells
-supported_shell_types = {
-    ShellType(shell) for shell in ShellType.get_all_values()
-}
-enable_click_shell_completion(
-    program_name=prog_name, shells=supported_shell_types
-)


### PR DESCRIPTION
<!--- Thanks for taking the time to fill out this pull request! -->
<!--- Please fill in the fields below to submit a pull request. 
The more information provided, the better. -->


# Description
<!--- What is the PR about? -->
Activating autocompletion requires modifying specific files, something that users might not want to happen by default.
Also, these files might have permissions that don't allow it.
With this PR we make autocomplete activation an option in the `rstuf` command.


<!--- Please reference the issue(s) this PR fixes. -->



# Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [ ] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct