### PR TITLE
fix: Stop tox `precommit` modifying files

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,7 @@ commands =
     bash -c 'pre-commit autoupdate'
     bash -c 'if ! diff -w .pre-commit-config.yaml tmp-tox-precommit.yaml; \
             then echo "⚠️ [WARNING] pre-commit hooks are outdated"; fi'
+    bash -c 'cp tmp-tox-precommit.yaml .pre-commit-config.yaml'
     bash -c 'rm tmp-tox-precommit.yaml'
 
 [testenv:docs]


### PR DESCRIPTION
<!--- Thanks for taking the time to fill out this pull request! -->
<!--- Please fill in the fields below to submit a pull request. 
The more information provided, the better. -->


# Description
<!--- What is the PR about? -->
Original bug reported by @MVrachev:
>  if precommit is not updated to latest versions of linters locally it will fail.

Some context:
> Do we have a GitHub automated pr

Yes, we do have in https://github.com/repository-service-tuf/repository-service-tuf-cli/blob/main/.github%2Fworkflows%2Fupdate-pre-commit-hooks.yml.

> Asking as currently, if precommit is not updated to latest versions of linters locally it will fail.

This should not be happening, it is supposed to only be a [warning message](https://github.com/repository-service-tuf/repository-service-tuf-cli/blob/main/tox.ini). If that's not happening then it's a bug.

> If we have the same automated pr updating the CLI precommit hooks we would be able to remove this requirement.

With the same reasoning we should remove also the requirements check, since we also have an automated PR for that (which I'm fine with)

For more information on the original idea of this hook: https://github.com/repository-service-tuf/repository-service-tuf-cli/pull/383#issuecomment-1734517873

---

### Fix
This tox step showed a warning (zero exit code) if the `.pre-commit-config.yaml` file was out-of-date and also updated it. When a file is updated `pre-commit` hooks exit with a non-zero code, whereas we only
wanted to print a warning with this hook.
Also, if you tried to commit again, because the pre-commit config file had been modified, `pre-commit` did not allow you to continue with your commit (error: "Your pre-commit configuration is unstaged.")

<!--- Please reference the issue(s) this PR fixes. -->
Fixes #(issue)


# Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct