### PR TITLE
Fix `import-artifacts` docs

### DIFF
--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -772,7 +772,7 @@ See the below CSV file example:
     │    --help                  -h                    Show this message and exit.                                                                                    │
     ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 
-    ❯ rstuf admin import-artifacts --db-uri postgresql://postgres:secret@127.0.0.1:5433 --csv artifacts-1of2.csv --csv artifacts-2of2.csv --metadata-url http://127.0.0.1:8080/
+    ❯ rstuf admin import-artifacts --db-uri postgresql://postgres:secret@127.0.0.1:5433 --csv artifacts-1of2.csv --csv artifacts-2of2.csv --api-server http://127.0.0.1:80/
     Import status: Loading data from ../repository-service-tuf/tests/data/artifacts-1of2.csv
     Import status: Importing ../repository-service-tuf/tests/data/artifacts-1of2.csv data
     Import status: ../repository-service-tuf/tests/data/artifacts-1of2.csv imported


### PR DESCRIPTION
This change fixes the `import-artifacts` example in the docs, so that it uses `--api-server` instead of the non-existing `--metadata-url` flag. This also partially resolves `import-artifacts` functional tests, which were failing in the CI.


<!--- Please reference the issue(s) this PR fixes. -->
Fixes #456


# Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [ n/a] Tests have been added for the bug fix or new feature
- [n/a ] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct