### PR TITLE
Update python-tuf to 4.0.0 & remove pinning & update to utc timezone

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,7 +15,7 @@ dynaconf = {extras = ["yaml"], version = "*"}
 isort = "*"
 sqlalchemy = "*"
 psycopg2 = "*"
-tuf = {ref = "be55b87", git = "git+https://github.com/theupdateframework/python-tuf"}
+tuf = "*"
 
 [dev-packages]
 black = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ab2c554a81d8fc85b9fb2b2e6034090782dbae0581eb488a997b90789d1aa68a"
+            "sha256": "9a48585d6fe4bed9930a31c3e1ffd3b3b7e86b0b44a4d4a2b8f1e26b0ea78ade"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -516,9 +516,13 @@
             "version": "==2.0.29"
         },
         "tuf": {
-            "git": "git+https://github.com/theupdateframework/python-tuf",
+            "hashes": [
+                "sha256:87df89e5e50b0bf85ec84b7aabdac41a54cddaa8c6ce85ac5fae38ea786a12f6",
+                "sha256:a22ab5fa6daf910b3052929fdce42ccad8a300e5e85715daaff9592aed980f7a"
+            ],
+            "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "ref": "be55b871dade1c1cb7686312ca9388f2484f8c68"
+            "version": "==4.0.0"
         },
         "typing-extensions": {
             "hashes": [
@@ -1436,14 +1440,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==20.25.1"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:206f5a15f2af3dbaee80769fb7dc6f249695e940acca08dfb2a4769fe61e538b",
-                "sha256:2884ed22e7d8961de1c9a05142eb69a247f120291bc0206a00a7642f09b5b715"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==3.18.1"
         }
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "rich",
   "rich-click",
   "securesystemslib[crypto]==0.31.0",
-  "tuf @ git+https://github.com/theupdateframework/python-tuf@be55b87"
+  "tuf"
 ]
 dynamic = ["version"]
 

--- a/repository_service_tuf/cli/admin/import_artifacts.py
+++ b/repository_service_tuf/cli/admin/import_artifacts.py
@@ -1,6 +1,6 @@
 import json
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from math import log
 from typing import Any, Dict, List
 
@@ -58,7 +58,7 @@ def _parse_csv_data(
                             == succinct_roles.get_role_for_target(path)
                         )
                     ).one()[0],
-                    "last_update": datetime.now(),
+                    "last_update": datetime.now(timezone.utc),
                 }
             )
 

--- a/repository_service_tuf/cli/admin/metadata.py
+++ b/repository_service_tuf/cli/admin/metadata.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 import copy
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
 from rich import align, box, markdown, prompt, table, text
@@ -348,7 +348,9 @@ def _modify_expiration(root_info: MetadataInfo):
             f"Current root expiration: [cyan]{root_info.expiration_str}[/]",
             highlight=False,  # disable built-in rich highlight
         )
-        if root_info.expiration < (datetime.now() + timedelta(days=1)):
+        if root_info.expiration < (
+            datetime.now(timezone.utc) + timedelta(days=1)
+        ):
             console.print("Root root has expired - expiration must be extend")
             change = True
 
@@ -363,7 +365,7 @@ def _modify_expiration(root_info: MetadataInfo):
         else:
             m = "Days to extend [cyan]root's expiration[/] starting from today"
             bump = _get_positive_int_input(m, "Expiration extension", 365)
-            new_expiry = datetime.now() + timedelta(days=bump)
+            new_expiry = datetime.now(timezone.utc) + timedelta(days=bump)
             new_exp_str = new_expiry.strftime("%Y-%b-%d")
             agree = prompt.Confirm.ask(
                 f"New root expiration: [cyan]{new_exp_str}[/]. Do you agree?"

--- a/repository_service_tuf/cli/admin2/helpers.py
+++ b/repository_service_tuf/cli/admin2/helpers.py
@@ -11,7 +11,7 @@ Advantages
 """
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional, Tuple
 
 # Magic import to unbreak `load_pem_private_key` - pyca/cryptography#10315
@@ -202,7 +202,8 @@ def _expiry_prompt(role: str) -> Tuple[int, datetime]:
         f"Please enter days until expiry for {role} role",
         default=DEFAULT_EXPIRY[role],
     )
-    date = datetime.utcnow() + timedelta(days=days)
+    today = datetime.now(timezone.utc).replace(microsecond=0)
+    date = today + timedelta(days=days)
     console.print(f"New expiry date is: {date:{EXPIRY_FORMAT}}")
 
     return days, date

--- a/repository_service_tuf/helpers/tuf.py
+++ b/repository_service_tuf/helpers/tuf.py
@@ -6,7 +6,7 @@ import base64
 import copy
 import json
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Tuple
 
@@ -345,7 +345,7 @@ class TUFManagement:
         # PEP 458 is unspecific about when to bump expiration, e.g. in the
         # course of a consistent snapshot only 'timestamp' is bumped:
         # https://www.python.org/dev/peps/pep-0458/#producing-consistent-snapshots
-        role.signed.expires = datetime.now().replace(
+        role.signed.expires = datetime.now(timezone.utc).replace(
             microsecond=0
         ) + timedelta(days=self.setup.expiration[Roles[role_name.upper()]])
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -72,7 +72,6 @@ types-requests==2.31.0.20240406; python_version >= '3.8'
 typing-extensions==4.11.0; python_version >= '3.8'
 urllib3==2.2.1; python_version >= '3.8'
 virtualenv==20.25.1; python_version >= '3.7'
-zipp==3.18.1; python_version >= '3.8'
 auto-click-auto==0.1.4; python_version >= '3.7' and python_version < '4.0'
 cffi==1.16.0; python_version >= '3.8'
 dynaconf[yaml]==3.2.5; python_version >= '3.8'
@@ -85,4 +84,4 @@ ruamel.yaml==0.18.6
 ruamel.yaml.clib==0.2.8; python_version < '3.13' and platform_python_implementation == 'CPython'
 securesystemslib[crypto]==0.31.0; python_version ~= '3.8'
 sqlalchemy==2.0.29; python_version >= '3.7'
-tuf@ git+https://github.com/theupdateframework/python-tuf@be55b871dade1c1cb7686312ca9388f2484f8c68
+tuf==4.0.0; python_version >= '3.8'

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,6 @@ ruamel.yaml==0.18.6
 ruamel.yaml.clib==0.2.8; python_version < '3.13' and platform_python_implementation == 'CPython'
 securesystemslib[crypto]==0.31.0; python_version ~= '3.8'
 sqlalchemy==2.0.29; python_version >= '3.7'
-tuf@ git+https://github.com/theupdateframework/python-tuf@be55b871dade1c1cb7686312ca9388f2484f8c68
+tuf==4.0.0; python_version >= '3.8'
 typing-extensions==4.11.0; python_version >= '3.8'
 urllib3==2.2.1; python_version >= '3.8'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from tempfile import TemporaryDirectory
 from typing import Any, Dict, List, Tuple
 
@@ -110,7 +110,7 @@ def test_inputs() -> Tuple[List[str], List[str], List[str], List[str]]:
 
 @pytest.fixture
 def root() -> Metadata[Root]:
-    return Metadata(Root(expires=datetime.now()))
+    return Metadata(Root(expires=datetime.now(timezone.utc)))
 
 
 @pytest.fixture

--- a/tests/unit/cli/admin/test_import_artifacts.py
+++ b/tests/unit/cli/admin/test_import_artifacts.py
@@ -1,4 +1,5 @@
 import datetime
+from datetime import timezone
 
 import pretend
 import pytest
@@ -70,9 +71,11 @@ class TestImportArtifactsFunctions:
             import_artifacts.__builtins__, "open", lambda *a: fake_file_obj
         )
 
-        fake_time = datetime.datetime(2019, 6, 16, 9, 5, 1)
+        fake_time = datetime.datetime(
+            2019, 6, 16, 9, 5, 1, tzinfo=timezone.utc
+        )
         fake_datetime = pretend.stub(
-            now=pretend.call_recorder(lambda: fake_time)
+            now=pretend.call_recorder(lambda a: fake_time)
         )
         monkeypatch.setattr(
             "repository_service_tuf.cli.admin.import_artifacts.datetime",
@@ -93,7 +96,7 @@ class TestImportArtifactsFunctions:
                 "targets_role": 15,
                 "published": False,
                 "action": "ADD",
-                "last_update": datetime.datetime(2019, 6, 16, 9, 5, 1),
+                "last_update": fake_time,
             },
             {
                 "path": "path/file2",
@@ -101,7 +104,7 @@ class TestImportArtifactsFunctions:
                 "targets_role": 15,
                 "published": False,
                 "action": "ADD",
-                "last_update": datetime.datetime(2019, 6, 16, 9, 5, 1),
+                "last_update": fake_time,
             },
         ]
         assert db.execute.calls == [pretend.call(True), pretend.call(True)]

--- a/tests/unit/cli/admin/test_metadata.py
+++ b/tests/unit/cli/admin/test_metadata.py
@@ -4,7 +4,7 @@
 
 import json
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pretend  # type: ignore
 import pytest
@@ -60,7 +60,7 @@ class TestMetadataUpdate:
         # Verify the changes in the new root
         assert root.signed.version == 2
 
-        expected = datetime.now() + timedelta(days=365)
+        expected = datetime.now(timezone.utc) + timedelta(days=365)
         assert root.signed.expires.date() == expected.date()
 
         is_steven_key_found = False
@@ -243,9 +243,9 @@ class TestMetadataUpdate:
         md_update_input,
         tmp_update_payload_path,
     ):
-        fake_date = datetime(2050, 6, 16, 9, 5, 1)
+        fake_date = datetime(2050, 6, 16, 9, 5, 1, tzinfo=timezone.utc)
         fake_datetime = pretend.stub(
-            now=pretend.call_recorder(lambda: fake_date)
+            now=pretend.call_recorder(lambda a: fake_date)
         )
         monkeypatch.setattr(
             "repository_service_tuf.cli.admin.metadata.datetime",

--- a/tests/unit/cli/artifact/test_download.py
+++ b/tests/unit/cli/artifact/test_download.py
@@ -393,6 +393,7 @@ class TestDownloadArtifacInteractionWithoutConfig:
                 ARTIFACT_URL,
             ],
             obj=test_context,
+            catch_exceptions=False,
         )
 
         assert "Using 'tofu' to Trust-On-First-Use" in test_result.output

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ setenv =
 commands =
     # Exclude tests for now as mocking and using pretend often leads to many
     # mypy warnings.
-    mypy --exclude tests/ .
+    mypy --exclude tests/ --exclude rstuf-umbrella/ .
 
 [run]
 omit = tests/*


### PR DESCRIPTION
# Description
<!--- What is the PR about? -->

Update python-tuf to version 4.0.0. See release notes here: https://github.com/theupdateframework/python-tuf/blob/v4.0.0/docs/CHANGELOG.md.
The new python-tuf version gives us the required `Root.get_verification_result()` API call which we use
for our new refactoring commands.

The specification defines `datetime` as UTC time zone:
https://theupdateframework.github.io/specification/latest/#file-formats-date-time
The python-tuf project updated all their datetime objects,  so it's time we do it now as well.
Additionally, I updated everywhere to replace `datetime.utc()` to `datetime.now(timezone.utc)`
as `datetime.utc()`  is documented for
deprecation and is officially deprecated from python 12:
https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow
Also, I added to all `datetime.now()` calls the argument `timezone.utc` to make sure that
we are consistent with python-tuf as python-tuf did that change as well: https://github.com/theupdateframework/python-tuf/pull/2573


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct