### PR TITLE
Tests: fix UT bugs regarding subprocess & python v12 changes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,7 @@ def test_context() -> Dict[str, Any]:
 
 @pytest.fixture
 def client() -> CliRunner:
-    runner = CliRunner()
+    runner = CliRunner(mix_stderr=False)
     return runner
 
 

--- a/tests/unit/cli/admin/test_import_artifacts.py
+++ b/tests/unit/cli/admin/test_import_artifacts.py
@@ -345,8 +345,8 @@ class TestImportArtifactsGroupCLI:
         result = client.invoke(
             import_artifacts.import_artifacts, options, obj=test_context
         )
-        assert result.exit_code == 1, result.output
-        assert "Requires '--api-server' " in result.output
+        assert result.exit_code == 1, result.stderr
+        assert "Requires '--api-server' " in result.stderr
 
     def test_import_artifacts_skip_publish_artifacts(
         self, client, test_context
@@ -474,7 +474,7 @@ class TestImportArtifactsGroupCLI:
             import_artifacts.import_artifacts, options, obj=test_context
         )
         assert result.exit_code == 1
-        assert "Server ERROR" in result.output, result.output
+        assert "Server ERROR" in result.stderr, result.stderr
 
     def test_import_artifacts_without_bootstrap(self, client, test_context):
         test_context["settings"].SERVER = "fake-server"
@@ -496,10 +496,10 @@ class TestImportArtifactsGroupCLI:
         result = client.invoke(
             import_artifacts.import_artifacts, options, obj=test_context
         )
-        assert result.exit_code == 1, result.output
+        assert result.exit_code == 1, result.stderr
         assert (
             "import-artifacts` requires bootstrap process done."
-            in result.output
+            in result.stderr
         )
         assert import_artifacts.bootstrap_status.calls == [
             pretend.call(test_context["settings"])

--- a/tests/unit/cli/admin_legacy/test_ceremony.py
+++ b/tests/unit/cli/admin_legacy/test_ceremony.py
@@ -67,7 +67,7 @@ class TestCeremonyInteraction:
             obj=test_context,
             catch_exceptions=False,
         )
-        assert "Ceremony aborted." in test_result.output
+        assert "Ceremony aborted." in test_result.stderr
         assert test_result.exit_code == 1
 
     def test_ceremony_start_not_ready_load_the_keys(
@@ -83,7 +83,7 @@ class TestCeremonyInteraction:
             obj=test_context,
             catch_exceptions=False,
         )
-        assert "Ceremony aborted." in test_result.output
+        assert "Ceremony aborted." in test_result.stderr
         assert test_result.exit_code == 1
 
     def test_ceremony_problem_loading_priv_key_fix_and_continue(
@@ -674,8 +674,8 @@ class TestCeremonyOptions:
             catch_exceptions=False,
         )
 
-        assert test_result.exit_code == 1, test_result.output
-        assert "permission denied" in test_result.output
+        assert test_result.exit_code == 1, test_result.stderr
+        assert "permission denied" in test_result.stderr
 
     def test_ceremony_option_bootstrap(
         self, client, test_context, test_inputs, test_setup
@@ -753,8 +753,8 @@ class TestCeremonyOptions:
             catch_exceptions=False,
         )
 
-        assert test_result.exit_code == 1, test_result.output
-        assert "System LOCKED for bootstrap" in test_result.output
+        assert test_result.exit_code == 1, test_result.stderr
+        assert "System LOCKED for bootstrap" in test_result.stderr
         assert ceremony.bootstrap_status.calls == [
             pretend.call(test_context["settings"])
         ]
@@ -814,8 +814,8 @@ class TestCeremonyOptions:
             catch_exceptions=False,
         )
 
-        assert test_result.exit_code == 1, test_result.output
-        assert "Requires '--api-server'" in test_result.output
+        assert test_result.exit_code == 1, test_result.stderr
+        assert "Requires '--api-server'" in test_result.stderr
 
     def test_ceremony_option_upload_missing_bootstrap(
         self, client, test_context, test_inputs, test_setup
@@ -836,5 +836,5 @@ class TestCeremonyOptions:
             catch_exceptions=False,
         )
 
-        assert test_result.exit_code == 1, test_result.output
-        assert "Requires '-b/--bootstrap' option." in test_result.output
+        assert test_result.exit_code == 1, test_result.stderr
+        assert "Requires '-b/--bootstrap' option." in test_result.stderr

--- a/tests/unit/cli/admin_legacy/test_metadata.py
+++ b/tests/unit/cli/admin_legacy/test_metadata.py
@@ -643,7 +643,7 @@ class TestMetadataUpdateOptions:
         )
         finish_msg = "Requires '--api-server' when using '--upload/-u'."
         assert result.exit_code == 1
-        assert finish_msg in result.output
+        assert finish_msg in result.stderr
 
     def test_metadata_update_passing_current_root(
         self, client, test_context, md_update_input, tmp_update_payload_path
@@ -825,8 +825,8 @@ class TestMetadataSign:
             input="\n".join(input_step),
             obj=test_context,
         )
-        assert test_result.exit_code == 1, test_result.output
-        assert "Interal Server Error" in test_result.output
+        assert test_result.exit_code == 1, test_result.stderr
+        assert "Interal Server Error" in test_result.stderr
         assert metadata.request_server.calls == [
             pretend.call(
                 "http://127.0.0.1",
@@ -854,8 +854,8 @@ class TestMetadataSign:
             input="\n".join(input_step),
             obj=test_context,
         )
-        assert test_result.exit_code == 1, test_result.output
-        assert "No data for you" in test_result.output
+        assert test_result.exit_code == 1, test_result.stderr
+        assert "No data for you" in test_result.stderr
         assert metadata.request_server.calls == [
             pretend.call(
                 "http://127.0.0.1",
@@ -882,8 +882,8 @@ class TestMetadataSign:
             input="\n".join(input_step),
             obj=test_context,
         )
-        assert test_result.exit_code == 1, test_result.output
-        assert "No metadata available for signing" in test_result.output
+        assert test_result.exit_code == 1, test_result.stderr
+        assert "No metadata available for signing" in test_result.stderr
         assert metadata.request_server.calls == [
             pretend.call(
                 "http://127.0.0.1",
@@ -1093,8 +1093,8 @@ class TestMetadataSign:
             input="\n".join(input_step),
             obj=test_context,
         )
-        assert test_result.exit_code == 1, test_result.output
-        assert "Loaded key is not 'Jimi Hendrix'" in test_result.output
+        assert test_result.exit_code == 1, test_result.stderr
+        assert "Loaded key is not 'Jimi Hendrix'" in test_result.stderr
         assert metadata.request_server.calls == [
             pretend.call(
                 "http://127.0.0.1",
@@ -1133,8 +1133,8 @@ class TestMetadataSign:
             input="\n".join(input_step),
             obj=test_context,
         )
-        assert test_result.exit_code == 1, test_result.output
-        assert "Problem signing the metadata" in test_result.output
+        assert test_result.exit_code == 1, test_result.stderr
+        assert "Problem signing the metadata" in test_result.stderr
         assert metadata.request_server.calls == [
             pretend.call(
                 "http://127.0.0.1",

--- a/tests/unit/cli/artifact/test_add.py
+++ b/tests/unit/cli/artifact/test_add.py
@@ -129,5 +129,5 @@ class TestAddArtifactInteraction:
 
             result = client.invoke(add.add, input, obj=test_context)
 
-        assert result.exit_code == 1, result.output
-        assert "Requires '--api-server'" in result.output
+        assert result.exit_code == 1, result.stderr
+        assert "Requires '--api-server'" in result.stderr

--- a/tests/unit/cli/artifact/test_download.py
+++ b/tests/unit/cli/artifact/test_download.py
@@ -44,7 +44,7 @@ class TestDownloadArtifacInteractionWithoutConfig:
             obj=test_context,
         )
 
-        assert "Please specify metadata url" in test_result.output
+        assert "Please specify metadata url" in test_result.stderr
         assert test_result.exit_code == 1
 
     def test_download_command_missing_artifacts_url(
@@ -61,7 +61,7 @@ class TestDownloadArtifacInteractionWithoutConfig:
             obj=test_context,
         )
 
-        assert "Please specify artifacts url" in test_result.output
+        assert "Please specify artifacts url" in test_result.stderr
         assert test_result.exit_code == 1
 
     def test_download_command_using_tofu(
@@ -362,7 +362,7 @@ class TestDownloadArtifacInteractionWithoutConfig:
         )
         assert f"Using trusted root in {metadata_dir}" in test_result.output
         err_msg = f"Failed to download artifact {ARTIFACT_NAME}"
-        assert err_msg in test_result.output
+        assert err_msg in test_result.stderr
         assert fake_build_metadata_dir.calls == [
             pretend.call(METADATA_URL),
         ]
@@ -397,9 +397,8 @@ class TestDownloadArtifacInteractionWithoutConfig:
         )
 
         assert "Using 'tofu' to Trust-On-First-Use" in test_result.output
-        assert "Failed to download initial root from" in test_result.output
-        assert "`tofu` was not successful" in test_result.output
-        assert test_result.exit_code == 1
+        assert "Failed to download initial root from" in test_result.stderr
+        assert "`tofu` was not successful" in test_result.stderr
         assert len(fake_is_file.calls) == 2
         assert pretend.call("foo_dir/root.json") in fake_is_file.calls
 
@@ -435,7 +434,7 @@ class TestDownloadArtifacInteractionWithConfig:
             [ARTIFACT_NAME],
             obj=test_context,
         )
-        assert "Please specify current repository" in test_result.output
+        assert "Please specify current repository" in test_result.stderr
 
     def test_download_command_no_repos_listed(
         self, client, test_context, test_setup, monkeypatch
@@ -456,8 +455,9 @@ class TestDownloadArtifacInteractionWithConfig:
             [ARTIFACT_NAME],
             obj=test_context,
         )
+        assert test_result.exit_code == 1
         assert (
-            "No reposotiroes listed in the config file" in test_result.output
+            "No reposotiroes listed in the config file" in test_result.stderr
         )
 
     def test_download_command_and_no_root_param(
@@ -518,8 +518,9 @@ class TestDownloadArtifacInteractionWithConfig:
             [ARTIFACT_NAME],
             obj=test_context,
         )
+        assert test_result.exit_code == 1
         err_msg = "Repository r1_expected is missing in the configuration file"
-        assert err_msg in test_result.output
+        assert err_msg in test_result.stderr
 
     def test_download_command_no_trusted_root(
         self, client, test_context, test_setup, monkeypatch
@@ -546,10 +547,8 @@ class TestDownloadArtifacInteractionWithConfig:
             [ARTIFACT_NAME],
             obj=test_context,
         )
-        assert "Trusted root is not cofigured." in test_result.output
-        msg = "You should either add it to your config file,"
-        assert msg in test_result.output
         assert test_result.exit_code == 1
+        assert "Trusted root is not cofigured." in test_result.stderr
 
 
 class TestDownloadArtifactOptions:

--- a/tests/unit/cli/artifact/test_repository.py
+++ b/tests/unit/cli/artifact/test_repository.py
@@ -139,7 +139,7 @@ class TestArtifactRepositoryInteraction:
         )
         assert (
             "Repository wrong_root_type has incorrect configuration."
-            in test_result.output
+            in test_result.stderr
         )
         assert test_result.exit_code == 1
 
@@ -150,7 +150,7 @@ class TestArtifactRepositoryInteraction:
             repository.show,
             obj=test_context,
         )
-        assert "There are no configured repositories" in test_result.output
+        assert "There are no configured repositories" in test_result.stderr
         assert test_result.exit_code == 1
 
         test_result = client.invoke(
@@ -160,7 +160,7 @@ class TestArtifactRepositoryInteraction:
         )
         assert (
             "Repository r1 is missing in your configuration"
-            in test_result.output
+            in test_result.stderr
         )
         assert test_result.exit_code == 1
 
@@ -248,8 +248,8 @@ class TestArtifactRepositoryInteraction:
         )
 
         assert test_result.exit_code == 2
-        assert "Try 'add --help' for help" in test_result.output
-        assert "Missing option '-m' / '--metadata-url'." in test_result.output
+        assert "Try 'add --help' for help" in test_result.stderr
+        assert "Missing option '-m' / '--metadata-url'." in test_result.stderr
 
     def test_repository_add_all_params(
         self, client, test_context, test_setup, monkeypatch
@@ -512,7 +512,7 @@ class TestArtifactRepositoryInteraction:
 
         assert (
             "There are no configured repositories to update"
-            in test_result.output
+            in test_result.stderr
         )
         assert test_result.exit_code == 1
 
@@ -690,9 +690,9 @@ class TestArtifactRepositoryInteraction:
 
         assert (
             "Repository non_existing not available in config. "
-            in test_result.output
+            in test_result.stderr
         )
-        assert "You can create it instead" in test_result.output
+        assert "You can create it instead" in test_result.stderr
         assert test_result.exit_code == 1
 
     def test_repository_delete_no_repos(
@@ -720,7 +720,7 @@ class TestArtifactRepositoryInteraction:
 
         assert (
             "There are no configured repositories. Nothing to delete"
-            in test_result.output
+            in test_result.stderr
         )
         assert test_result.exit_code == 1
 
@@ -762,7 +762,7 @@ class TestArtifactRepositoryInteraction:
 
         assert (
             "Repository non_existing not available. Nothing to delete"
-            in test_result.output
+            in test_result.stderr
         )
         assert test_result.exit_code == 1
 

--- a/tests/unit/cli/key/test_generate.py
+++ b/tests/unit/cli/key/test_generate.py
@@ -37,7 +37,7 @@ class TestGenerateInteraction:
 
         assert (
             "Please select one of the available options"
-            not in test_result.output
+            not in test_result.stderr
         )
 
         assert test_result.exit_code == 1
@@ -86,7 +86,9 @@ class TestGenerateInteraction:
                 catch_exceptions=False,
             )
 
-            mock_keypair.called_once()
+            mock_keypair.assert_called_once_with(
+                password=password, filepath=filename
+            )
             assert test_result.exit_code == 0
             assert generate.load_key.calls == [
                 pretend.call(filename, key_type, password, "")
@@ -176,7 +178,7 @@ class TestGenerateInteraction:
             in test_result.output
         )
 
-        assert "Key creation aborted." in test_result.output
+        assert "Key creation aborted." in test_result.stderr
 
         # password not shown in output
         assert password not in test_result.output

--- a/tests/unit/cli/task/test_info.py
+++ b/tests/unit/cli/task/test_info.py
@@ -54,4 +54,4 @@ class TestTaskInfoInteraction:
         )
 
         assert result.exit_code == 1
-        assert output_message in result.output
+        assert output_message in result.stderr


### PR DESCRIPTION
<!--- Thanks for taking the time to fill out this pull request! -->
<!--- Please fill in the fields below to submit a pull request. 
The more information provided, the better. -->


# Description
<!--- What is the PR about? -->

Fix unit tests caused by internal Python changes:
Subprocesses have changed where exception messages are stored.
From stdout exception messages are moved to stderr and we need to adapt.

Additionally, we use `called_once` for one test for a mock where we
need to migrate to `assert_called_once_with` as for python 12.
called_once is gone: https://github.com/python/cpython/issues/100690

Finally, Fix "ValueError: stderr not separately captured.
This error is given by `subprocess` when we want to access the stderr
of the test_result object returned from `click.invoke`.
This is fixed by using "mix_stderr" on `CliRunner` level.

https://click.palletsprojects.com/en/latest/api/#testing


# Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct