### PR TITLE
Improvements on top of new sign and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ metadata/
 rstuf-umbrella/
 payload.json
 metadata-update-payload.json
+ceremony-payload.json
+sign-payload.json
+update-payload.json
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -176,7 +176,7 @@ sign (``sign``)
 
     ❯ rstuf admin metadata sign -h
 
-    Usage: rstuf admin metadata sign [OPTIONS] ROOT_IN [PREV_ROOT_IN]
+    Usage: rstuf admin metadata sign [OPTIONS] [SIGNING_JSON_INPUT_FILE]
 
     Add one signature to root metadata.
     There are two ways to use this command:
@@ -184,7 +184,7 @@ sign (``sign``)
     2) provide a local file using the SIGNING_JSON_INPUT_FILE argument
     When using method 2:
      - 'SIGNING_JSON_INPUT_FILE' must be a file containing the JSON response from the 'GET /api/v1/metadata/sign' API endpoint.
-     - '--api_server' will be ignored.
+     - '--api-server' will be ignored.
      - the result of the command will be saved into the 'sign-payload.json' file unless a different name is provided with '--save'.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────╮

--- a/repository_service_tuf/cli/admin/ceremony.py
+++ b/repository_service_tuf/cli/admin/ceremony.py
@@ -48,7 +48,7 @@ def ceremony(save) -> None:
     """Bootstrap Ceremony to create initial root metadata and RSTUF config."""
     console.print("\n", Markdown("# Metadata Bootstrap Tool"))
 
-    if not save:
+    if not save:  # pragma: no cover
         _warn_no_save()
 
     root = Root()

--- a/repository_service_tuf/cli/admin/sign.py
+++ b/repository_service_tuf/cli/admin/sign.py
@@ -116,8 +116,10 @@ def sign(
     if api_server:
         settings.SERVER = api_server
     if settings.get("SERVER") is None and signing_json_input_file is None:
-        error = "Either '--api-sever' or 'SIGNING_JSON_INPUT_FILE' must be set"
-        raise click.ClickException(error)
+        raise click.ClickException(
+            "Either '--api-sever'/'SERVER' in RSTUF config or "
+            "'SIGNING_JSON_INPUT_FILE' must be set"
+        )
     ###########################################################################
     # Load roots
     pending_roles: Dict[str, Dict[str, Any]]
@@ -169,7 +171,7 @@ def sign(
     # Send payload to the API and/or save it locally
 
     payload = SignPayload(signature=signature.to_dict())
-    if save or not api_server:
+    if save or not settings.get("SERVER"):
         path = save.name if save is not None else DEFAULT_PATH
         save_payload(path, asdict(payload))
         console.print(f"Saved result to '{path}'")

--- a/repository_service_tuf/cli/admin/sign.py
+++ b/repository_service_tuf/cli/admin/sign.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, Optional
 
 import click
 from rich.markdown import Markdown
-from rich.prompt import Prompt
 from tuf.api.metadata import Metadata, Root
 
 # TODO: Should we use the global rstuf console exclusively? We do use it for
@@ -34,42 +33,36 @@ from repository_service_tuf.helpers.api_client import (
     send_payload,
     task_status,
 )
+from repository_service_tuf.helpers.tuf import save_payload
 
 
-def _get_pending_roles(
-    settings: Any,
-    api_server: Optional[str] = None,
-    signing_input: Optional[Dict[str, Any]] = None,
-) -> Dict[str, Dict[str, Any]]:
-    """Get dictionary of pending roles for signing."""
-    data: Dict[str, Any]
-    if signing_input:
-        data = signing_input
-    else:
-        if api_server:
-            settings.SERVER = api_server
-
-        if settings.get("SERVER") is None:
-            api_server = Prompt.ask("\n[cyan]API[/] URL address")
-            settings.SERVER = api_server
-
-        response = request_server(
-            settings.SERVER, URL.METADATA_SIGN.value, Methods.GET
-        )
-        if response.status_code != 200:
-            raise click.ClickException(
-                f"Failed to fetch metadata for signing. Error: {response.text}"
-            )
-
-        data = response.json().get("data")
-        if data is None:
-            raise click.ClickException(response.text)
+def _parse_pending_data(pending_roles_resp: Dict[str, Any]) -> Dict[str, Any]:
+    data = pending_roles_resp.get("data")
+    if data is None:
+        error = "'data' field missing from api server response/file input"
+        raise click.ClickException(error)
 
     pending_roles: Dict[str, Dict[str, Any]] = data.get("metadata", {})
     if len(pending_roles) == 0:
         raise click.ClickException("No metadata available for signing")
 
     return pending_roles
+
+
+def _get_pending_roles(settings: Any) -> Dict[str, Dict[str, Any]]:
+    """Get dictionary of pending roles for signing."""
+    response = request_server(
+        settings.SERVER, URL.METADATA_SIGN.value, Methods.GET
+    )
+    if response.status_code != 200:
+        raise click.ClickException(
+            f"Failed to fetch metadata for signing. Error: {response.text}"
+        )
+
+    return _parse_pending_data(response.json())
+
+
+DEFAULT_PATH = "sign-payload.json"
 
 
 @metadata.command()  # type: ignore
@@ -82,8 +75,8 @@ def _get_pending_roles(
     "--save",
     "-s",
     is_flag=False,
-    flag_value="sign-payload.json",
-    help="Write json result to FILENAME (default: 'sign-payload.json')",
+    flag_value=DEFAULT_PATH,
+    help=f"Write json result to FILENAME (default: '{DEFAULT_PATH}')",
     type=click.File("w"),
 )
 @click.argument(
@@ -105,27 +98,33 @@ def sign(
 
     1) utilizing access to the RSTUF API and signing pending metadata roles
 
-    2) provide a local file using the SIGNING_JSON_INPUT_FILE argument
+    2) provide a local file using the 'SIGNING_JSON_INPUT_FILE' argument
+
+    The result of this command will be saved locally in a 'sign-payload.json'
+    file if '--api-server' is not provided or at custom path if '--save' is
+    used.
 
     When using method 2:
 
     - 'SIGNING_JSON_INPUT_FILE' must be a file containing the JSON response
     from the 'GET /api/v1/metadata/sign' API endpoint.
 
-    - '--api_server' will be ignored.
-
-    - the result of the command will be saved into the 'sign-payload.json' file
-    unless a different name is provided with '--save'.
+    - '--api-server' will be ignored.
     """
     console.print("\n", Markdown("# Metadata Signing Tool"))
+    settings = context.obj["settings"]
+    if api_server:
+        settings.SERVER = api_server
+    if settings.get("SERVER") is None and signing_json_input_file is None:
+        error = "Either '--api-sever' or 'SIGNING_JSON_INPUT_FILE' must be set"
+        raise click.ClickException(error)
     ###########################################################################
     # Load roots
-    settings = context.obj["settings"]
-    signing_input: Optional[Dict[str, Any]] = None
+    pending_roles: Dict[str, Dict[str, Any]]
     if signing_json_input_file:
-        signing_input = json.load(signing_json_input_file)  # type: ignore
-
-    pending_roles = _get_pending_roles(settings, api_server, signing_input)
+        pending_roles = _parse_pending_data(json.load(signing_json_input_file))  # type: ignore  # noqa
+    else:
+        pending_roles = _get_pending_roles(settings)
 
     root_md = Metadata[Root].from_dict(pending_roles[Root.type])
 
@@ -169,17 +168,8 @@ def sign(
     ###########################################################################
     # Send payload to the API and save it locally
     payload = SignPayload(signature=signature.to_dict())
-    if save:
-        json.dump(asdict(payload), save, indent=2)  # type: ignore
-        console.print(f"Saved result to '{save.name}'")
-    elif signing_json_input_file:
-        with open("sign-payload.json", "w") as out_file:
-            json.dump(asdict(payload), out_file, indent=2)
-
-        console.print("Saved result to 'sign-payload.json'")
-
-    if not signing_json_input_file:
-        console.print("\nSending signature")
+    if settings.get("SERVER"):
+        console.print(f"\nSending signature to {settings.SERVER}")
         task_id = send_payload(
             settings,
             URL.METADATA_SIGN.value,
@@ -189,3 +179,8 @@ def sign(
         )
         task_status(task_id, settings, "Metadata sign status:")
         console.print("\nMetadata Signed and sent to the API! 🔑\n")
+
+    if save or not api_server:
+        path = save.name if save is not None else DEFAULT_PATH
+        save_payload(path, asdict(payload))
+        console.print(f"Saved result to '{path}'")

--- a/repository_service_tuf/cli/admin/sign.py
+++ b/repository_service_tuf/cli/admin/sign.py
@@ -166,8 +166,14 @@ def sign(
     signature = _add_signature_prompt(root_md, key)
 
     ###########################################################################
-    # Send payload to the API and save it locally
+    # Send payload to the API and/or save it locally
+
     payload = SignPayload(signature=signature.to_dict())
+    if save or not api_server:
+        path = save.name if save is not None else DEFAULT_PATH
+        save_payload(path, asdict(payload))
+        console.print(f"Saved result to '{path}'")
+
     if settings.get("SERVER"):
         console.print(f"\nSending signature to {settings.SERVER}")
         task_id = send_payload(
@@ -179,8 +185,3 @@ def sign(
         )
         task_status(task_id, settings, "Metadata sign status:")
         console.print("\nMetadata Signed and sent to the API! 🔑\n")
-
-    if save or not api_server:
-        path = save.name if save is not None else DEFAULT_PATH
-        save_payload(path, asdict(payload))
-        console.print(f"Saved result to '{path}'")

--- a/repository_service_tuf/cli/key/__init__.py
+++ b/repository_service_tuf/cli/key/__init__.py
@@ -5,7 +5,7 @@
 from repository_service_tuf.cli import click, rstuf
 
 
-@rstuf.group()  # type: ignore
+@rstuf.group()  # pragma: no cover  # type: ignore
 def key():
     """Cryptographic Key Commands"""
 

--- a/repository_service_tuf/helpers/api_client.py
+++ b/repository_service_tuf/helpers/api_client.py
@@ -151,7 +151,7 @@ def task_status(
                     # If task.state is "ERRORED" it means there is an internal
                     # RSTUF error and data contains error information.
                     raise click.ClickException(
-                        f"Errored: {data["result"]["error"]}"
+                        f"Errored: {data['result']['error']}"
                     )
 
             else:

--- a/repository_service_tuf/helpers/api_client.py
+++ b/repository_service_tuf/helpers/api_client.py
@@ -147,6 +147,12 @@ def task_status(
                     raise click.ClickException(
                         f"Failed: {state_response.text}"
                     )
+                elif state == "ERRORED":
+                    # If task.state is "ERRORED" it means there is an internal
+                    # RSTUF error and data contains error information.
+                    raise click.ClickException(
+                        f"Errored: {data["result"]["error"]}"
+                    )
 
             else:
                 raise click.ClickException(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -252,11 +252,9 @@ def ed25519_signer(ed25519_key):
     return CryptoSigner(private_key, ed25519_key)
 
 
-def invoke_command(
-    client, cmd, inputs, args, test_context=None, std_err_empty=True
-) -> Result:
+def invoke_command(client, cmd, inputs, args, std_err_empty=True) -> Result:
     out_file_name = "out_file_.json"
-    context = _create_test_context() if test_context is None else test_context
+    context = _create_test_context()
     with client.isolated_filesystem():
         result_obj = client.invoke(
             cmd,
@@ -270,5 +268,7 @@ def invoke_command(
             assert result_obj.stderr == ""
             with open(out_file_name) as f:
                 result_obj.data = json.load(f)
+
+            result_obj.context = context
 
     return result_obj

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -255,10 +255,12 @@ def ed25519_signer(ed25519_key):
     return CryptoSigner(private_key, ed25519_key)
 
 
-def invoke_command(cmd, inputs, args, std_err_empty=True) -> Result:
+def invoke_command(
+    cmd, inputs, args, std_err_empty=True, test_context=None
+) -> Result:
     client = _create_client()
     out_file_name = "out_file_.json"
-    context = _create_test_context()
+    context = _create_test_context() if test_context is None else test_context
     with client.isolated_filesystem():
         result_obj = client.invoke(
             cmd,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,10 +49,13 @@ def test_context() -> Dict[str, Any]:
     return _create_test_context()
 
 
+def _create_client() -> CliRunner:
+    return CliRunner(mix_stderr=False)
+
+
 @pytest.fixture
 def client() -> CliRunner:
-    runner = CliRunner(mix_stderr=False)
-    return runner
+    return _create_client()
 
 
 @pytest.fixture
@@ -252,7 +255,8 @@ def ed25519_signer(ed25519_key):
     return CryptoSigner(private_key, ed25519_key)
 
 
-def invoke_command(client, cmd, inputs, args, std_err_empty=True) -> Result:
+def invoke_command(cmd, inputs, args, std_err_empty=True) -> Result:
+    client = _create_client()
     out_file_name = "out_file_.json"
     context = _create_test_context()
     with client.isolated_filesystem():

--- a/tests/files/payload/sign_pending_roles.json
+++ b/tests/files/payload/sign_pending_roles.json
@@ -1,147 +1,149 @@
 {
-  "metadata": {
-    "root": {
-      "signatures": [
-        {
-          "keyid": "50d7e110ad65f3b2dba5c3cfc8c5ca259be9774cc26be3410044ffd4be3aa5f3",
-          "sig": "3046022100e4590f8f82fd8166b37590250036d474a2f15e6e9979482fd59892b97b870b5b0221008f10b6affcf16d907ee27a41887cd360c26c9d3f7fd9fda2d23807d51c5c5822"
-        },
-        {
-          "keyid": "2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241",
-          "sig": "72ebfe7ace89d79197923cd42a4e597db2fa8c3a357f8241958d619dfcb5380921cb03f226e11ac4c3ad45e9a73211d608bb94e821c7909812334905fc46ccab924bf36548e51438b409b03e58cabb121ec0383de083f0d12ed04cc6e37698bd0deb6382235a116cf49a4ec4584a40becf4e02fa17d36daddbd8db3c03fdacdd036c89180f6a9993a291c99b7d41862c9bdfd939a5fee4aa35392e5aa151babf7c35e8d02adf01523c1783de63a6849d277e8acf89674edffb66ccec4e27d4ee53cd29ea63ea1e4cbc7b4dd7ffb0de6c724eecd0eee8ebfe110aeaeb19c4fe4cca0b3fdb3cd1181209c5ece62c6a3934d6a80fa906c035bf9d12937f0f64b527"
-        }
-      ],
-      "signed": {
-        "_type": "root",
-        "version": 2,
-        "spec_version": "1.0.31",
-        "expires": "2025-12-31T23:59:59Z",
-        "consistent_snapshot": true,
-        "keys": {
-          "50d7e110ad65f3b2dba5c3cfc8c5ca259be9774cc26be3410044ffd4be3aa5f3": {
-            "keytype": "ecdsa",
-            "scheme": "ecdsa-sha2-nistp256",
-            "keyval": {
-              "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEcLYSZyFGeKdWNt5dWFbnv6N9NyHC\noUNLcG6GZIxLwN8Q8MUdHdOOxGkDnyBRSJpIZ/r/oDECSTwfCYhdogweLA==\n-----END PUBLIC KEY-----\n"
-            },
-            "x-rstuf-key-name": "JanisJoplin's Key"
+  "data": {
+    "metadata": {
+      "root": {
+        "signatures": [
+          {
+            "keyid": "50d7e110ad65f3b2dba5c3cfc8c5ca259be9774cc26be3410044ffd4be3aa5f3",
+            "sig": "3046022100e4590f8f82fd8166b37590250036d474a2f15e6e9979482fd59892b97b870b5b0221008f10b6affcf16d907ee27a41887cd360c26c9d3f7fd9fda2d23807d51c5c5822"
           },
-          "2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241": {
-            "keytype": "rsa",
-            "scheme": "rsassa-pss-sha256",
-            "keyval": {
-              "public": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwhX6rioiL/cX5Ys32InF\nU52H8tL14QeX0tacZdb+AwcH6nIh97h3RSHvGD7Xy6uaMRmGldAnSVYwJHqoJ5j2\nynVzU/RFpr+6n8Ps0QFg5GmlEqZboFjLbS0bsRQcXXnqJNsVLEPT3ULvu1rFRbWz\nAMFjNtNNk5W/u0GEzXn3D03jIdhD8IKAdrTRf0VMD9TRCXLdMmEU2vkf1NVUnOTb\n/dRX5QA8TtBylVnouZknbavQ0J/pPlHLfxUgsKzodwDlJmbPG9BWwXqQCmP0DgOG\nNIZ1X281MOBaGbkNVEuntNjCSaQxQjfALVVU5NAfal2cwMINtqaoc7Wa+TWvpFEI\nWwIDAQAB\n-----END PUBLIC KEY-----\n"
-            },
-            "x-rstuf-key-name": "JoeCocker's Key"
-          },
-          "cb20fa1061dde8e6267e0bef0981766aaadae168e917030f7f26edc7a0bab9c2": {
-            "keytype": "ecdsa",
-            "scheme": "ecdsa-sha2-nistp256",
-            "keyval": {
-              "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpsXQqNQPymbXz9efGsDRNyifLujg\nYRSp/TWmVDVBlLF2Ia+bSZD2GU5iPGlKsIX129yvUu1qQ49kdATqiuB6ow==\n-----END PUBLIC KEY-----\n"
-            },
-            "x-rstuf-key-name": "New Online Key",
-            "x-rstuf-online-key-uri": "fn:cb20fa1061dde8e6267e0bef0981766aaadae168e917030f7f26edc7a0bab9c2"
+          {
+            "keyid": "2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241",
+            "sig": "72ebfe7ace89d79197923cd42a4e597db2fa8c3a357f8241958d619dfcb5380921cb03f226e11ac4c3ad45e9a73211d608bb94e821c7909812334905fc46ccab924bf36548e51438b409b03e58cabb121ec0383de083f0d12ed04cc6e37698bd0deb6382235a116cf49a4ec4584a40becf4e02fa17d36daddbd8db3c03fdacdd036c89180f6a9993a291c99b7d41862c9bdfd939a5fee4aa35392e5aa151babf7c35e8d02adf01523c1783de63a6849d277e8acf89674edffb66ccec4e27d4ee53cd29ea63ea1e4cbc7b4dd7ffb0de6c724eecd0eee8ebfe110aeaeb19c4fe4cca0b3fdb3cd1181209c5ece62c6a3934d6a80fa906c035bf9d12937f0f64b527"
           }
-        },
-        "roles": {
-          "root": {
-            "keyids": [
-              "50d7e110ad65f3b2dba5c3cfc8c5ca259be9774cc26be3410044ffd4be3aa5f3",
-              "2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241"
-            ],
-            "threshold": 2
+        ],
+        "signed": {
+          "_type": "root",
+          "version": 2,
+          "spec_version": "1.0.31",
+          "expires": "2025-12-31T23:59:59Z",
+          "consistent_snapshot": true,
+          "keys": {
+            "50d7e110ad65f3b2dba5c3cfc8c5ca259be9774cc26be3410044ffd4be3aa5f3": {
+              "keytype": "ecdsa",
+              "scheme": "ecdsa-sha2-nistp256",
+              "keyval": {
+                "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEcLYSZyFGeKdWNt5dWFbnv6N9NyHC\noUNLcG6GZIxLwN8Q8MUdHdOOxGkDnyBRSJpIZ/r/oDECSTwfCYhdogweLA==\n-----END PUBLIC KEY-----\n"
+              },
+              "x-rstuf-key-name": "JanisJoplin's Key"
+            },
+            "2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241": {
+              "keytype": "rsa",
+              "scheme": "rsassa-pss-sha256",
+              "keyval": {
+                "public": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwhX6rioiL/cX5Ys32InF\nU52H8tL14QeX0tacZdb+AwcH6nIh97h3RSHvGD7Xy6uaMRmGldAnSVYwJHqoJ5j2\nynVzU/RFpr+6n8Ps0QFg5GmlEqZboFjLbS0bsRQcXXnqJNsVLEPT3ULvu1rFRbWz\nAMFjNtNNk5W/u0GEzXn3D03jIdhD8IKAdrTRf0VMD9TRCXLdMmEU2vkf1NVUnOTb\n/dRX5QA8TtBylVnouZknbavQ0J/pPlHLfxUgsKzodwDlJmbPG9BWwXqQCmP0DgOG\nNIZ1X281MOBaGbkNVEuntNjCSaQxQjfALVVU5NAfal2cwMINtqaoc7Wa+TWvpFEI\nWwIDAQAB\n-----END PUBLIC KEY-----\n"
+              },
+              "x-rstuf-key-name": "JoeCocker's Key"
+            },
+            "cb20fa1061dde8e6267e0bef0981766aaadae168e917030f7f26edc7a0bab9c2": {
+              "keytype": "ecdsa",
+              "scheme": "ecdsa-sha2-nistp256",
+              "keyval": {
+                "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpsXQqNQPymbXz9efGsDRNyifLujg\nYRSp/TWmVDVBlLF2Ia+bSZD2GU5iPGlKsIX129yvUu1qQ49kdATqiuB6ow==\n-----END PUBLIC KEY-----\n"
+              },
+              "x-rstuf-key-name": "New Online Key",
+              "x-rstuf-online-key-uri": "fn:cb20fa1061dde8e6267e0bef0981766aaadae168e917030f7f26edc7a0bab9c2"
+            }
           },
-          "timestamp": {
-            "keyids": [
-              "cb20fa1061dde8e6267e0bef0981766aaadae168e917030f7f26edc7a0bab9c2"
-            ],
-            "threshold": 1
-          },
-          "snapshot": {
-            "keyids": [
-              "cb20fa1061dde8e6267e0bef0981766aaadae168e917030f7f26edc7a0bab9c2"
-            ],
-            "threshold": 1
-          },
-          "targets": {
-            "keyids": [
-              "cb20fa1061dde8e6267e0bef0981766aaadae168e917030f7f26edc7a0bab9c2"
-            ],
-            "threshold": 1
+          "roles": {
+            "root": {
+              "keyids": [
+                "50d7e110ad65f3b2dba5c3cfc8c5ca259be9774cc26be3410044ffd4be3aa5f3",
+                "2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241"
+              ],
+              "threshold": 2
+            },
+            "timestamp": {
+              "keyids": [
+                "cb20fa1061dde8e6267e0bef0981766aaadae168e917030f7f26edc7a0bab9c2"
+              ],
+              "threshold": 1
+            },
+            "snapshot": {
+              "keyids": [
+                "cb20fa1061dde8e6267e0bef0981766aaadae168e917030f7f26edc7a0bab9c2"
+              ],
+              "threshold": 1
+            },
+            "targets": {
+              "keyids": [
+                "cb20fa1061dde8e6267e0bef0981766aaadae168e917030f7f26edc7a0bab9c2"
+              ],
+              "threshold": 1
+            }
           }
         }
-      }
-    },
-    "trusted_root": {
-      "signatures": [
-        {
-          "keyid": "c6d8bf2e4f48b41ac2ce8eca21415ca8ef68c133b47fc33df03d4070a7e1e9cc",
-          "sig": "828a659bc34972504b9dab16bc44818b8a7d49ffee2a9021df6a6be4dd3b7a026d1f890b952303d1cf32dda90fbdf60e9fcfeb5f0af6498f0f55cad31c750a02"
-        },
-        {
-          "keyid": "50d7e110ad65f3b2dba5c3cfc8c5ca259be9774cc26be3410044ffd4be3aa5f3",
-          "sig": "3045022100bcce9491bd23530674a014c4af202f59047de039ab8dee0bf177220b7c045c52022017d74c26be9d525ab65a81403e48fa826a1f6c79db910a601c524e8228f61df9"
-        }
-      ],
-      "signed": {
-        "_type": "root",
-        "version": 1,
-        "spec_version": "1.0.31",
-        "expires": "2025-12-31T23:59:59Z",
-        "consistent_snapshot": true,
-        "keys": {
-          "c6d8bf2e4f48b41ac2ce8eca21415ca8ef68c133b47fc33df03d4070a7e1e9cc": {
-            "keytype": "ed25519",
-            "scheme": "ed25519",
-            "keyval": {
-              "public": "4f66dabebcf30628963786001984c0b75c175cdcf3bc4855933a2628f0cd0a0f"
-            },
-            "x-rstuf-key-name": "JimiHendrix's Key"
+      },
+      "trusted_root": {
+        "signatures": [
+          {
+            "keyid": "c6d8bf2e4f48b41ac2ce8eca21415ca8ef68c133b47fc33df03d4070a7e1e9cc",
+            "sig": "828a659bc34972504b9dab16bc44818b8a7d49ffee2a9021df6a6be4dd3b7a026d1f890b952303d1cf32dda90fbdf60e9fcfeb5f0af6498f0f55cad31c750a02"
           },
-          "50d7e110ad65f3b2dba5c3cfc8c5ca259be9774cc26be3410044ffd4be3aa5f3": {
-            "keytype": "ecdsa",
-            "scheme": "ecdsa-sha2-nistp256",
-            "keyval": {
-              "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEcLYSZyFGeKdWNt5dWFbnv6N9NyHC\noUNLcG6GZIxLwN8Q8MUdHdOOxGkDnyBRSJpIZ/r/oDECSTwfCYhdogweLA==\n-----END PUBLIC KEY-----\n"
-            },
-            "x-rstuf-key-name": "JanisJoplin's Key"
-          },
-          "0d9d3d4bad91c455bc03921daa95774576b86625ac45570d0cac025b08e65043": {
-            "keytype": "rsa",
-            "scheme": "rsassa-pss-sha256",
-            "keyval": {
-              "public": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwJNtmJy0bky0VZHhJoVw\nVR0oIto8ndLLicnaHPDUfFsv2dTP50uLiYuYhU/RLTh+PIMm9dU5gvfSQ0YIUFHO\nfdcDCBaMNYR9z9c9kvWkfgxP4H7cMdy9ev3yh4pL+ua64AT1598QxmF0RSp9p8P4\nUDPJC4XsgVz3kKeCSQAgz02MJ+KdHyTDP+rgOuWQfVL8bz53puMSSFojiaEJTmZQ\n7eBnI2n6UF6AAV6eo6Dc4cgPQLSjhDqcfoHCyk/AzpTQO5EV+ahofYmV/kQQtr7g\nz8MQXoKRwCbfIcWhPyfPNReOo7fqVK3uK3kkD1ouoNSr9DFRcnUbsX4QR/CQLcoP\nXwIDAQAB\n-----END PUBLIC KEY-----\n"
-            },
-            "x-rstuf-key-name": "Online Key",
-            "x-rstuf-online-key-uri": "fn:0d9d3d4bad91c455bc03921daa95774576b86625ac45570d0cac025b08e65043"
+          {
+            "keyid": "50d7e110ad65f3b2dba5c3cfc8c5ca259be9774cc26be3410044ffd4be3aa5f3",
+            "sig": "3045022100bcce9491bd23530674a014c4af202f59047de039ab8dee0bf177220b7c045c52022017d74c26be9d525ab65a81403e48fa826a1f6c79db910a601c524e8228f61df9"
           }
-        },
-        "roles": {
-          "root": {
-            "keyids": [
-              "c6d8bf2e4f48b41ac2ce8eca21415ca8ef68c133b47fc33df03d4070a7e1e9cc",
-              "50d7e110ad65f3b2dba5c3cfc8c5ca259be9774cc26be3410044ffd4be3aa5f3"
-            ],
-            "threshold": 2
+        ],
+        "signed": {
+          "_type": "root",
+          "version": 1,
+          "spec_version": "1.0.31",
+          "expires": "2025-12-31T23:59:59Z",
+          "consistent_snapshot": true,
+          "keys": {
+            "c6d8bf2e4f48b41ac2ce8eca21415ca8ef68c133b47fc33df03d4070a7e1e9cc": {
+              "keytype": "ed25519",
+              "scheme": "ed25519",
+              "keyval": {
+                "public": "4f66dabebcf30628963786001984c0b75c175cdcf3bc4855933a2628f0cd0a0f"
+              },
+              "x-rstuf-key-name": "JimiHendrix's Key"
+            },
+            "50d7e110ad65f3b2dba5c3cfc8c5ca259be9774cc26be3410044ffd4be3aa5f3": {
+              "keytype": "ecdsa",
+              "scheme": "ecdsa-sha2-nistp256",
+              "keyval": {
+                "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEcLYSZyFGeKdWNt5dWFbnv6N9NyHC\noUNLcG6GZIxLwN8Q8MUdHdOOxGkDnyBRSJpIZ/r/oDECSTwfCYhdogweLA==\n-----END PUBLIC KEY-----\n"
+              },
+              "x-rstuf-key-name": "JanisJoplin's Key"
+            },
+            "0d9d3d4bad91c455bc03921daa95774576b86625ac45570d0cac025b08e65043": {
+              "keytype": "rsa",
+              "scheme": "rsassa-pss-sha256",
+              "keyval": {
+                "public": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwJNtmJy0bky0VZHhJoVw\nVR0oIto8ndLLicnaHPDUfFsv2dTP50uLiYuYhU/RLTh+PIMm9dU5gvfSQ0YIUFHO\nfdcDCBaMNYR9z9c9kvWkfgxP4H7cMdy9ev3yh4pL+ua64AT1598QxmF0RSp9p8P4\nUDPJC4XsgVz3kKeCSQAgz02MJ+KdHyTDP+rgOuWQfVL8bz53puMSSFojiaEJTmZQ\n7eBnI2n6UF6AAV6eo6Dc4cgPQLSjhDqcfoHCyk/AzpTQO5EV+ahofYmV/kQQtr7g\nz8MQXoKRwCbfIcWhPyfPNReOo7fqVK3uK3kkD1ouoNSr9DFRcnUbsX4QR/CQLcoP\nXwIDAQAB\n-----END PUBLIC KEY-----\n"
+              },
+              "x-rstuf-key-name": "Online Key",
+              "x-rstuf-online-key-uri": "fn:0d9d3d4bad91c455bc03921daa95774576b86625ac45570d0cac025b08e65043"
+            }
           },
-          "timestamp": {
-            "keyids": [
-              "0d9d3d4bad91c455bc03921daa95774576b86625ac45570d0cac025b08e65043"
-            ],
-            "threshold": 1
-          },
-          "snapshot": {
-            "keyids": [
-              "0d9d3d4bad91c455bc03921daa95774576b86625ac45570d0cac025b08e65043"
-            ],
-            "threshold": 1
-          },
-          "targets": {
-            "keyids": [
-              "0d9d3d4bad91c455bc03921daa95774576b86625ac45570d0cac025b08e65043"
-            ],
-            "threshold": 1
+          "roles": {
+            "root": {
+              "keyids": [
+                "c6d8bf2e4f48b41ac2ce8eca21415ca8ef68c133b47fc33df03d4070a7e1e9cc",
+                "50d7e110ad65f3b2dba5c3cfc8c5ca259be9774cc26be3410044ffd4be3aa5f3"
+              ],
+              "threshold": 2
+            },
+            "timestamp": {
+              "keyids": [
+                "0d9d3d4bad91c455bc03921daa95774576b86625ac45570d0cac025b08e65043"
+              ],
+              "threshold": 1
+            },
+            "snapshot": {
+              "keyids": [
+                "0d9d3d4bad91c455bc03921daa95774576b86625ac45570d0cac025b08e65043"
+              ],
+              "threshold": 1
+            },
+            "targets": {
+              "keyids": [
+                "0d9d3d4bad91c455bc03921daa95774576b86625ac45570d0cac025b08e65043"
+              ],
+              "threshold": 1
+            }
           }
         }
       }

--- a/tests/unit/cli/admin/test_ceremony.py
+++ b/tests/unit/cli/admin/test_ceremony.py
@@ -5,7 +5,7 @@ from tests.conftest import _PAYLOADS, _PEMS, invoke_command
 
 
 class TestCeremony:
-    def test_ceremony(self, client, patch_getpass, patch_utcnow):
+    def test_ceremony(self, patch_getpass, patch_utcnow):
         inputs = [
             "",  # Please enter days until expiry for timestamp role (1)
             "",  # Please enter days until expiry for snapshot role (1)
@@ -32,7 +32,7 @@ class TestCeremony:
             f"{_PEMS / 'JJ.ecdsa'}",  # Please enter path to encrypted private key  # noqa
         ]
 
-        result = invoke_command(client, ceremony.ceremony, inputs, [])
+        result = invoke_command(ceremony.ceremony, inputs, [])
 
         with open(_PAYLOADS / "ceremony.json") as f:
             expected = json.load(f)

--- a/tests/unit/cli/admin/test_sign.py
+++ b/tests/unit/cli/admin/test_sign.py
@@ -309,7 +309,9 @@ class TestSignError:
             lambda *a, **kw: fake_response
         )
         args = ["--api-server", "http://127.0.0.1"]
-        test_result = invoke_command(sign.sign, inputs, args, False)
+        test_result = invoke_command(
+            sign.sign, inputs, args, std_err_empty=False
+        )
 
         assert test_result.exit_code == 1, test_result.output
         assert "Previous root v1 needed to sign root v2" in test_result.stderr
@@ -344,7 +346,9 @@ class TestSignError:
             lambda *a, **kw: fake_response
         )
         args = ["--api-server", "http://127.0.0.1"]
-        test_result = invoke_command(sign.sign, inputs, args, False)
+        test_result = invoke_command(
+            sign.sign, inputs, args, std_err_empty=False
+        )
 
         assert test_result.exit_code == 1, test_result.output
         assert "Metadata already fully signed." in test_result.stderr

--- a/tests/unit/cli/admin/test_sign.py
+++ b/tests/unit/cli/admin/test_sign.py
@@ -14,9 +14,7 @@ from tests.conftest import _PAYLOADS, _PEMS, _ROOTS, invoke_command
 
 
 class TestSign:
-    def test_sign_with_previous_root(
-        self, client, test_context, patch_getpass
-    ):
+    def test_sign_with_previous_root(self, client, patch_getpass):
         inputs = [
             "http://127.0.0.1",  # API URL address
             "1",  # Please enter signing key index
@@ -46,7 +44,7 @@ class TestSign:
         sign.send_payload = pretend.call_recorder(lambda *a: "fake-taskid")
         sign.task_status = pretend.call_recorder(lambda *a: "OK")
 
-        result = invoke_command(client, sign.sign, inputs, [], test_context)
+        result = invoke_command(client, sign.sign, inputs, [])
 
         with open(_PAYLOADS / "sign.json") as f:
             expected = json.load(f)
@@ -65,7 +63,7 @@ class TestSign:
         ]
         assert sign.send_payload.calls == [
             pretend.call(
-                test_context["settings"],
+                result.context["settings"],
                 URL.METADATA_SIGN.value,
                 {
                     "role": "root",
@@ -81,12 +79,12 @@ class TestSign:
         assert sign.task_status.calls == [
             pretend.call(
                 "fake-taskid",
-                test_context["settings"],
+                result.context["settings"],
                 "Metadata sign status:",
             )
         ]
 
-    def test_sign_bootstap_root(self, client, test_context, patch_getpass):
+    def test_sign_bootstap_root(self, client, patch_getpass):
         inputs = [
             "http://127.0.0.1",  # API URL address
             "1",  # Please enter signing key index
@@ -109,7 +107,7 @@ class TestSign:
         sign.send_payload = pretend.call_recorder(lambda *a: "fake-taskid")
         sign.task_status = pretend.call_recorder(lambda *a: "OK")
 
-        result = invoke_command(client, sign.sign, inputs, [], test_context)
+        result = invoke_command(client, sign.sign, inputs, [])
 
         expected = {
             "keyid": "c6d8bf2e4f48b41ac2ce8eca21415ca8ef68c133b47fc33df03d4070a7e1e9cc",  # noqa
@@ -128,7 +126,7 @@ class TestSign:
         ]
         assert sign.send_payload.calls == [
             pretend.call(
-                test_context["settings"],
+                result.context["settings"],
                 URL.METADATA_SIGN.value,
                 {
                     "role": "root",
@@ -144,7 +142,7 @@ class TestSign:
         assert sign.task_status.calls == [
             pretend.call(
                 "fake-taskid",
-                test_context["settings"],
+                result.context["settings"],
                 "Metadata sign status:",
             )
         ]
@@ -214,7 +212,7 @@ class TestSign:
 
 class TestSignError:
     def test_sign_with_previous_root_but_wrong_version(
-        self, client, test_context, patch_getpass
+        self, client, patch_getpass
     ):
         inputs = [
             "http://127.0.0.1",  # API URL address
@@ -238,9 +236,7 @@ class TestSignError:
         sign.request_server = pretend.call_recorder(
             lambda *a, **kw: fake_response
         )
-        test_result = invoke_command(
-            client, sign.sign, inputs, [], test_context, False
-        )
+        test_result = invoke_command(client, sign.sign, inputs, [], False)
 
         assert test_result.exit_code == 1, test_result.output
         assert "Previous root v1 needed to sign root v2" in test_result.stderr
@@ -252,9 +248,7 @@ class TestSignError:
             )
         ]
 
-    def test_sign_fully_signed_metadata(
-        self, client, test_context, patch_getpass
-    ):
+    def test_sign_fully_signed_metadata(self, client, patch_getpass):
         inputs = [
             "http://127.0.0.1",  # API URL address
             "1",  # Please enter signing key index
@@ -277,9 +271,7 @@ class TestSignError:
         sign.request_server = pretend.call_recorder(
             lambda *a, **kw: fake_response
         )
-        test_result = invoke_command(
-            client, sign.sign, inputs, [], test_context, False
-        )
+        test_result = invoke_command(client, sign.sign, inputs, [], False)
 
         assert test_result.exit_code == 1, test_result.output
         assert "Metadata already fully signed." in test_result.stderr

--- a/tests/unit/cli/admin/test_sign.py
+++ b/tests/unit/cli/admin/test_sign.py
@@ -16,24 +16,12 @@ from tests.conftest import _PAYLOADS, _PEMS, _ROOTS, invoke_command
 class TestSign:
     def test_sign_with_previous_root(self, patch_getpass):
         inputs = [
-            "http://127.0.0.1",  # API URL address
             "1",  # Please enter signing key index
             f"{_PEMS / 'JH.ed25519'}",  # Please enter path to encrypted private key  # noqa
         ]
-        with open(f"{_ROOTS / 'v2.json'}") as f:
-            v2_das_root = f.read()
+        with open(f"{_PAYLOADS / 'sign_pending_roles.json'}") as f:
+            fake_response_data = json.load(f)
 
-        with open(f"{_ROOTS / 'v1.json'}") as f:
-            v1_das_root = f.read()
-
-        fake_response_data = {
-            "data": {
-                "metadata": {
-                    "trusted_root": json.loads(v1_das_root),
-                    "root": json.loads(v2_das_root),
-                }
-            }
-        }
         fake_response = pretend.stub(
             json=pretend.call_recorder(lambda: fake_response_data),
             status_code=200,
@@ -43,8 +31,9 @@ class TestSign:
         )
         sign.send_payload = pretend.call_recorder(lambda *a: "fake-taskid")
         sign.task_status = pretend.call_recorder(lambda *a: "OK")
+        args = ["--api-server", "http://127.0.0.1"]
 
-        result = invoke_command(sign.sign, inputs, [])
+        result = invoke_command(sign.sign, inputs, args)
 
         with open(_PAYLOADS / "sign.json") as f:
             expected = json.load(f)
@@ -86,7 +75,6 @@ class TestSign:
 
     def test_sign_bootstap_root(self, patch_getpass):
         inputs = [
-            "http://127.0.0.1",  # API URL address
             "1",  # Please enter signing key index
             f"{_PEMS / 'JH.ed25519'}",  # Please enter path to encrypted private key  # noqa
         ]
@@ -106,8 +94,9 @@ class TestSign:
         )
         sign.send_payload = pretend.call_recorder(lambda *a: "fake-taskid")
         sign.task_status = pretend.call_recorder(lambda *a: "OK")
+        args = ["--api-server", "http://127.0.0.1"]
 
-        result = invoke_command(sign.sign, inputs, [])
+        result = invoke_command(sign.sign, inputs, args)
 
         expected = {
             "keyid": "c6d8bf2e4f48b41ac2ce8eca21415ca8ef68c133b47fc33df03d4070a7e1e9cc",  # noqa
@@ -196,6 +185,7 @@ class TestSign:
                 obj=test_context,
                 catch_exceptions=False,
             )
+            assert result.stderr == ""
             with open(default_path) as f:
                 result.data = json.load(f)
 
@@ -209,11 +199,95 @@ class TestSign:
         assert result.data["signature"]["sig"] == expected["sig"]
         assert f"Saved result to '{default_path}'" in result.output
 
+    def test_sign_bootstap_root_with_file_input_with_api_server(
+        self, patch_getpass
+    ):
+        inputs = [
+            "1",  # Please enter signing key index
+            f"{_PEMS / 'JH.ed25519'}",  # Please enter path to encrypted private key  # noqa
+        ]
+        sign.send_payload = pretend.call_recorder(lambda *a: "fake-taskid")
+        sign.task_status = pretend.call_recorder(lambda *a: "OK")
+        sign_input_path = f"{_PAYLOADS / 'sign_pending_roles.json'}"
+        api_server = "http://localhost:80"
+        args = ["--api-server", api_server, sign_input_path]
+        result = invoke_command(sign.sign, inputs, args)
+
+        expected = {
+            "keyid": "c6d8bf2e4f48b41ac2ce8eca21415ca8ef68c133b47fc33df03d4070a7e1e9cc",  # noqa
+            "sig": "828a659bc34972504b9dab16bc44818b8a7d49ffee2a9021df6a6be4dd3b7a026d1f890b952303d1cf32dda90fbdf60e9fcfeb5f0af6498f0f55cad31c750a02",  # noqa
+        }
+
+        assert result.data["role"] == "root"
+        assert result.data["signature"]["keyid"] == expected["keyid"]
+        assert "Metadata Signed and sent to the API! 🔑" in result.output
+        assert sign.send_payload.calls == [
+            pretend.call(
+                result.context["settings"],
+                URL.METADATA_SIGN.value,
+                {
+                    "role": "root",
+                    "signature": {
+                        "keyid": "c6d8bf2e4f48b41ac2ce8eca21415ca8ef68c133b47fc33df03d4070a7e1e9cc",  # noqa
+                        "sig": "917046f9076eae41876be7c031be149aa2a960fd21f0d52f72128f55d9c423e2ec1632f98c96693dd801bd064e37efd6e5a5d32712fd5701a42099ece6b88c05",  # noqa
+                    },
+                },
+                "Metadata sign accepted.",
+                "Metadata sign",
+            )
+        ]
+        assert sign.task_status.calls == [
+            pretend.call(
+                "fake-taskid",
+                result.context["settings"],
+                "Metadata sign status:",
+            )
+        ]
+
+    def test_sign_bootstap_root_with_file_input_no_api_server_no_save(
+        self, client, patch_getpass, test_context
+    ):
+        inputs = [
+            "1",  # Please enter signing key index
+            f"{_PEMS / 'JH.ed25519'}",  # Please enter path to encrypted private key  # noqa
+        ]
+
+        sign_input_path = f"{_PAYLOADS / 'sign_pending_roles.json'}"
+        args = [sign_input_path]
+
+        with client.isolated_filesystem():
+            result = client.invoke(
+                sign.sign,
+                args=args,
+                input="\n".join(inputs),
+                obj=test_context,
+                catch_exceptions=False,
+            )
+
+            assert result.stderr == ""
+            with open(sign.DEFAULT_PATH) as f:
+                result.data = json.load(f)
+
+        expected = {
+            "keyid": "c6d8bf2e4f48b41ac2ce8eca21415ca8ef68c133b47fc33df03d4070a7e1e9cc",  # noqa
+            "sig": "828a659bc34972504b9dab16bc44818b8a7d49ffee2a9021df6a6be4dd3b7a026d1f890b952303d1cf32dda90fbdf60e9fcfeb5f0af6498f0f55cad31c750a02",  # noqa
+        }
+
+        assert result.data["role"] == "root"
+        assert result.data["signature"]["keyid"] == expected["keyid"]
+        assert "Metadata Signed and sent to the API! 🔑" not in result.output
+        assert f"Saved result to {sign.DEFAULT_PATH}"
+
+    def test_sign_no_api_server_and_no_file_input(self):
+        result = invoke_command(sign.sign, [], [], std_err_empty=False)
+
+        err = "Either '--api-sever' or 'SIGNING_JSON_INPUT_FILE' must be set"
+        assert err in result.stderr
+
 
 class TestSignError:
     def test_sign_with_previous_root_but_wrong_version(self, patch_getpass):
         inputs = [
-            "http://127.0.0.1",  # API URL address
             "1",  # Please enter signing key index
             f"{_PEMS / 'JH.ed25519'}",  # Please enter path to encrypted private key  # noqa
         ]
@@ -234,7 +308,8 @@ class TestSignError:
         sign.request_server = pretend.call_recorder(
             lambda *a, **kw: fake_response
         )
-        test_result = invoke_command(sign.sign, inputs, [], False)
+        args = ["--api-server", "http://127.0.0.1"]
+        test_result = invoke_command(sign.sign, inputs, args, False)
 
         assert test_result.exit_code == 1, test_result.output
         assert "Previous root v1 needed to sign root v2" in test_result.stderr
@@ -248,7 +323,6 @@ class TestSignError:
 
     def test_sign_fully_signed_metadata(self, patch_getpass):
         inputs = [
-            "http://127.0.0.1",  # API URL address
             "1",  # Please enter signing key index
             f"{_PEMS / 'JH.ed25519'}",  # Please enter path to encrypted private key  # noqa
         ]
@@ -269,7 +343,8 @@ class TestSignError:
         sign.request_server = pretend.call_recorder(
             lambda *a, **kw: fake_response
         )
-        test_result = invoke_command(sign.sign, inputs, [], False)
+        args = ["--api-server", "http://127.0.0.1"]
+        test_result = invoke_command(sign.sign, inputs, args, False)
 
         assert test_result.exit_code == 1, test_result.output
         assert "Metadata already fully signed." in test_result.stderr
@@ -283,148 +358,66 @@ class TestSignError:
 
 
 class TestHelpers:
-    def test__get_pending_roles_api_server_passed(self):
-        fake_settings = pretend.stub(
-            SERVER=None,
-            get=pretend.call_recorder(lambda a: fake_settings.SERVER),
-        )
-        api_server = "http://localhost:80"
-        expected_pending_runs = {"root": {}, "trusted_root": {}}
-        response = pretend.stub(
-            status_code=200,
-            json=pretend.call_recorder(
-                lambda: {"data": {"metadata": expected_pending_runs}}
-            ),
-        )
-        sign.request_server = pretend.call_recorder(lambda *a, **kw: response)
-        result = sign._get_pending_roles(fake_settings, api_server)
-        assert result == expected_pending_runs
-        assert fake_settings.SERVER == api_server
-        assert fake_settings.get.calls == [pretend.call("SERVER")]
-        assert sign.request_server.calls == [
-            pretend.call(
-                api_server, sign.URL.METADATA_SIGN.value, sign.Methods.GET
-            )
-        ]
-        assert response.json.calls == [pretend.call()]
+    def test__parse_pending_data(self):
+        fake_md = ["md1", "md2"]
+        result = sign._parse_pending_data({"data": {"metadata": fake_md}})
 
-    def test__get_pending_roles_api_server_not_provided(self, monkeypatch):
-        fake_settings = pretend.stub(
-            SERVER=None,
-            get=pretend.call_recorder(lambda a: fake_settings.SERVER),
-        )
-        api_server = "http://localhost:80"
-        fake_prompt = pretend.stub(
-            ask=pretend.call_recorder(lambda a: api_server)
-        )
-        monkeypatch.setattr(
-            "repository_service_tuf.cli.admin.sign.Prompt", fake_prompt
-        )
-        expected_pending_runs = {"root": {}, "trusted_root": {}}
-        response = pretend.stub(
-            status_code=200,
-            json=pretend.call_recorder(
-                lambda: {"data": {"metadata": expected_pending_runs}}
-            ),
-        )
-        sign.request_server = pretend.call_recorder(lambda *a, **kw: response)
-        result = sign._get_pending_roles(fake_settings)
-        assert result == expected_pending_runs
-        assert fake_settings.SERVER == api_server
-        assert fake_settings.get.calls == [pretend.call("SERVER")]
-        assert fake_prompt.ask.calls == [
-            pretend.call("\n[cyan]API[/] URL address")
-        ]
-        assert sign.request_server.calls == [
-            pretend.call(
-                api_server, sign.URL.METADATA_SIGN.value, sign.Methods.GET
-            )
-        ]
-        assert response.json.calls == [pretend.call()]
+        assert result == fake_md
 
-    def test__get_pending_roles_provide_signing_input(self):
-        path = f"{_PAYLOADS}/sign_pending_roles.json"
-        with open(path) as f:
-            input = json.load(f)
-
-        result = sign._get_pending_roles(None, signing_input=input)
-        assert result == input["metadata"]
-
-    def test__get_pending_roles_provide_signing_input_no_metadata(self):
-        path = f"{_PAYLOADS / 'sign.json'}"
-        with open(path) as f:
-            input = json.load(f)
-
+    def test__parse_pending_data_missing_metadata(self):
         with pytest.raises(click.ClickException) as e:
-            sign._get_pending_roles(None, signing_input=input)
+            sign._parse_pending_data({"data": {}})
 
         assert "No metadata available for signing" in str(e)
+
+    def test__parse_pending_data_missing_data(self):
+        with pytest.raises(click.ClickException) as e:
+            sign._parse_pending_data({})
+
+        err = "'data' field missing from api server response/file input"
+        assert err in str(e)
+
+    def test__get_pending_roles_request(self, monkeypatch):
+        fake_settings = pretend.stub(SERVER=None)
+        fake_json = pretend.stub()
+        response = pretend.stub(
+            status_code=200, json=pretend.call_recorder(lambda: fake_json)
+        )
+        sign.request_server = pretend.call_recorder(lambda *a, **kw: response)
+
+        parsed_data = pretend.stub()
+        fake__parse_pending_data = pretend.call_recorder(lambda a: parsed_data)
+        monkeypatch.setattr(
+            sign, "_parse_pending_data", fake__parse_pending_data
+        )
+
+        result = sign._get_pending_roles(fake_settings)
+
+        assert result == parsed_data
+        assert sign.request_server.calls == [
+            pretend.call(
+                fake_settings.SERVER,
+                sign.URL.METADATA_SIGN.value,
+                sign.Methods.GET,
+            )
+        ]
+        assert response.json.calls == [pretend.call()]
+        assert fake__parse_pending_data.calls == [pretend.call(fake_json)]
 
     def test__get_pending_roles_request_bad_status_code(self):
         fake_settings = pretend.stub(
-            SERVER=None,
-            get=pretend.call_recorder(lambda a: fake_settings.SERVER),
+            SERVER="http://localhost:80",
         )
-        api_server = "http://localhost:80"
         response = pretend.stub(status_code=400, text="")
         sign.request_server = pretend.call_recorder(lambda *a, **kw: response)
         with pytest.raises(click.ClickException) as e:
-            sign._get_pending_roles(fake_settings, api_server)
+            sign._get_pending_roles(fake_settings)
 
         assert "Failed to fetch metadata for signing" in str(e)
-        assert fake_settings.SERVER == api_server
-        assert fake_settings.get.calls == [pretend.call("SERVER")]
         assert sign.request_server.calls == [
             pretend.call(
-                api_server, sign.URL.METADATA_SIGN.value, sign.Methods.GET
-            )
-        ]
-
-    def test__get_pending_roles_request_data_none(self):
-        fake_settings = pretend.stub(
-            SERVER=None,
-            get=pretend.call_recorder(lambda a: fake_settings.SERVER),
-        )
-        api_server = "http://localhost:80"
-        response = pretend.stub(
-            status_code=200,
-            json=pretend.call_recorder(lambda: {"data": None}),
-            text="Error: Bad data",
-        )
-        sign.request_server = pretend.call_recorder(lambda *a, **kw: response)
-        with pytest.raises(click.ClickException) as e:
-            sign._get_pending_roles(fake_settings, api_server)
-
-        assert "Error: Bad data" in str(e)
-        assert fake_settings.SERVER == api_server
-        assert fake_settings.get.calls == [pretend.call("SERVER")]
-        assert sign.request_server.calls == [
-            pretend.call(
-                api_server, sign.URL.METADATA_SIGN.value, sign.Methods.GET
-            )
-        ]
-        assert response
-
-    def test__get_pending_roles_request_data_no_metadata(self):
-        fake_settings = pretend.stub(
-            SERVER=None,
-            get=pretend.call_recorder(lambda a: fake_settings.SERVER),
-        )
-        api_server = "http://localhost:80"
-        response_json = pretend.stub(
-            status_code=200, json=pretend.call_recorder(lambda: {"data": {}})
-        )
-        sign.request_server = pretend.call_recorder(
-            lambda *a, **kw: response_json
-        )
-        with pytest.raises(click.ClickException) as e:
-            sign._get_pending_roles(fake_settings, api_server)
-
-        assert "No metadata available for signing" in str(e)
-        assert fake_settings.SERVER == api_server
-        assert fake_settings.get.calls == [pretend.call("SERVER")]
-        assert sign.request_server.calls == [
-            pretend.call(
-                api_server, sign.URL.METADATA_SIGN.value, sign.Methods.GET
+                fake_settings.SERVER,
+                sign.URL.METADATA_SIGN.value,
+                sign.Methods.GET,
             )
         ]

--- a/tests/unit/cli/admin/test_sign.py
+++ b/tests/unit/cli/admin/test_sign.py
@@ -14,7 +14,7 @@ from tests.conftest import _PAYLOADS, _PEMS, _ROOTS, invoke_command
 
 
 class TestSign:
-    def test_sign_with_previous_root(self, client, patch_getpass):
+    def test_sign_with_previous_root(self, patch_getpass):
         inputs = [
             "http://127.0.0.1",  # API URL address
             "1",  # Please enter signing key index
@@ -44,7 +44,7 @@ class TestSign:
         sign.send_payload = pretend.call_recorder(lambda *a: "fake-taskid")
         sign.task_status = pretend.call_recorder(lambda *a: "OK")
 
-        result = invoke_command(client, sign.sign, inputs, [])
+        result = invoke_command(sign.sign, inputs, [])
 
         with open(_PAYLOADS / "sign.json") as f:
             expected = json.load(f)
@@ -84,7 +84,7 @@ class TestSign:
             )
         ]
 
-    def test_sign_bootstap_root(self, client, patch_getpass):
+    def test_sign_bootstap_root(self, patch_getpass):
         inputs = [
             "http://127.0.0.1",  # API URL address
             "1",  # Please enter signing key index
@@ -107,7 +107,7 @@ class TestSign:
         sign.send_payload = pretend.call_recorder(lambda *a: "fake-taskid")
         sign.task_status = pretend.call_recorder(lambda *a: "OK")
 
-        result = invoke_command(client, sign.sign, inputs, [])
+        result = invoke_command(sign.sign, inputs, [])
 
         expected = {
             "keyid": "c6d8bf2e4f48b41ac2ce8eca21415ca8ef68c133b47fc33df03d4070a7e1e9cc",  # noqa
@@ -211,9 +211,7 @@ class TestSign:
 
 
 class TestSignError:
-    def test_sign_with_previous_root_but_wrong_version(
-        self, client, patch_getpass
-    ):
+    def test_sign_with_previous_root_but_wrong_version(self, patch_getpass):
         inputs = [
             "http://127.0.0.1",  # API URL address
             "1",  # Please enter signing key index
@@ -236,7 +234,7 @@ class TestSignError:
         sign.request_server = pretend.call_recorder(
             lambda *a, **kw: fake_response
         )
-        test_result = invoke_command(client, sign.sign, inputs, [], False)
+        test_result = invoke_command(sign.sign, inputs, [], False)
 
         assert test_result.exit_code == 1, test_result.output
         assert "Previous root v1 needed to sign root v2" in test_result.stderr
@@ -248,7 +246,7 @@ class TestSignError:
             )
         ]
 
-    def test_sign_fully_signed_metadata(self, client, patch_getpass):
+    def test_sign_fully_signed_metadata(self, patch_getpass):
         inputs = [
             "http://127.0.0.1",  # API URL address
             "1",  # Please enter signing key index
@@ -271,7 +269,7 @@ class TestSignError:
         sign.request_server = pretend.call_recorder(
             lambda *a, **kw: fake_response
         )
-        test_result = invoke_command(client, sign.sign, inputs, [], False)
+        test_result = invoke_command(sign.sign, inputs, [], False)
 
         assert test_result.exit_code == 1, test_result.output
         assert "Metadata already fully signed." in test_result.stderr

--- a/tests/unit/cli/admin/test_sign.py
+++ b/tests/unit/cli/admin/test_sign.py
@@ -281,8 +281,7 @@ class TestSign:
     def test_sign_no_api_server_and_no_file_input(self):
         result = invoke_command(sign.sign, [], [], std_err_empty=False)
 
-        err = "Either '--api-sever' or 'SIGNING_JSON_INPUT_FILE' must be set"
-        assert err in result.stderr
+        assert "Either '--api-sever'/'SERVER'" in result.stderr
 
 
 class TestSignError:

--- a/tests/unit/cli/admin/test_update.py
+++ b/tests/unit/cli/admin/test_update.py
@@ -30,7 +30,7 @@ class TestMetadataUpdate:
         ]
         args = [f"{_ROOTS / 'v1.json'}"]
 
-        result = invoke_command(client, update.update, inputs, args)
+        result = invoke_command(update.update, inputs, args)
         with open(_PAYLOADS / "update.json") as f:
             expected = json.load(f)
 


### PR DESCRIPTION
# Description
The changes aim to:
1. fail early if none of 'api-server' or 'SIGNING_JSON_INPUT_FILE' is
provided
2. allow the combination of 'api-server' AND 'SIGNING_JSON_INPUT_FILE'
3. if 'save' is not used and 'api-server' is not provided then save
result at DEFAULT_PATH (sign_payload.json at the moment)
4. simplify the sign helper functions
5. modify the 'tests/files/payload/sign_pending_roles.json' example
payload to follow the actual API response from "GET /api/v1/metadata"

Finally, the changes address some small comments made by @lukpueh in a previous pr
and improve tests.

# Additional requirements
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct