### PR TITLE
Add tests for ceremony edge cases & improve type annotations

### DIFF
--- a/repository_service_tuf/cli/admin/helpers.py
+++ b/repository_service_tuf/cli/admin/helpers.py
@@ -126,9 +126,7 @@ class _PositiveIntPrompt(IntPrompt):
 
 
 class _MoreThan1Prompt(IntPrompt):
-    validate_error_message = (
-        "[prompt.invalid]Please enter a positive number above 1"
-    )
+    validate_error_message = "[prompt.invalid]Please enter threshold above 1"
 
     def process_response(self, value: str) -> int:
         return_value: int = super().process_response(value)

--- a/repository_service_tuf/cli/admin/helpers.py
+++ b/repository_service_tuf/cli/admin/helpers.py
@@ -125,6 +125,18 @@ class _PositiveIntPrompt(IntPrompt):
         return return_value
 
 
+class _MoreThan1Prompt(IntPrompt):
+    validate_error_message = (
+        "[prompt.invalid]Please enter a positive number above 1"
+    )
+
+    def process_response(self, value: str) -> int:
+        return_value: int = super().process_response(value)
+        if return_value < 2:
+            raise InvalidResponse(self.validate_error_message)
+        return return_value
+
+
 def _load_signer_from_file_prompt(public_key: SSlibKey) -> CryptoSigner:
     """Prompt for path to private key and password, return Signer."""
     path = Prompt.ask("Please enter path to encrypted private key")
@@ -227,8 +239,7 @@ def _online_settings_prompt() -> _OnlineSettings:
 
 
 def _root_threshold_prompt() -> int:
-    # TODO: validate default threshold policy?
-    return _PositiveIntPrompt.ask("Please enter root threshold")
+    return _MoreThan1Prompt.ask("Please enter root threshold")
 
 
 def _choose_add_remove_skip_key_prompt(

--- a/repository_service_tuf/cli/admin/sign.py
+++ b/repository_service_tuf/cli/admin/sign.py
@@ -86,7 +86,7 @@ DEFAULT_PATH = "sign-payload.json"
 )
 @click.pass_context
 def sign(
-    context: Any,
+    context: click.Context,
     api_server: Optional[str],
     save: Optional[click.File],
     signing_json_input_file: Optional[click.File],

--- a/repository_service_tuf/helpers/tuf.py
+++ b/repository_service_tuf/helpers/tuf.py
@@ -269,7 +269,8 @@ class MetadataInfo:
         except UnsignedMetadataError:
             trusted_keys_amount = 0
             for keyid in self._trusted_md.signed.roles["root"].keyids:
-                if keyid in self.signing_keys:
+                # Will remove this code soon, no need to test.
+                if keyid in self.signing_keys:  # pragma: no cover
                     trusted_keys_amount += 1
 
             t = self._trusted_md.signed.roles["root"].threshold

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,10 +7,11 @@ import os
 from datetime import datetime, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import pretend
 import pytest  # type: ignore
+from click import Command, Context
 from click.testing import CliRunner, Result  # type: ignore
 from cryptography.hazmat.primitives.serialization import (
     load_pem_private_key,
@@ -293,7 +294,11 @@ def ed25519_signer(ed25519_key):
 
 
 def invoke_command(
-    cmd, inputs, args, std_err_empty=True, test_context=None
+    cmd: Command,
+    inputs: List[str],
+    args: List[str],
+    std_err_empty: bool = True,
+    test_context: Optional[Context] = None,
 ) -> Result:
     client = _create_client()
     out_file_name = "out_file_.json"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,6 +132,43 @@ def test_inputs() -> Tuple[List[str], List[str], List[str], List[str]]:
 
 
 @pytest.fixture
+def ceremony_inputs() -> Tuple[List[str], List[str], List[str], List[str]]:
+    input_step1 = [  # Configure online role settings and root expiration
+        "",  # Please enter days until expiry for timestamp role (1)
+        "",  # Please enter days until expiry for snapshot role (1)
+        "",  # Please enter days until expiry for targets role (365)
+        "",  # Please enter days until expiry for bins role (1)
+        "4",  # Please enter number of delegated hash bins [2/4/8/16/32/64/128/256/512/1024/2048/4096/8192/16384] (256)  # noqa
+        "",  # Please enter days until expiry for root role (365)
+    ]
+    input_step2 = [  # Configure Root Keys
+        "2",  # Please enter root threshold
+        f"{_PEMS / 'JC.pub'}",  # Please enter path to public key
+        "my rsa key",  # Please enter key name
+        "0",  # Please press 0 to add key, or remove key by entering its index  # noqa
+        f"{_PEMS / 'JH.pub'}",  # Please enter path to public key
+        "JimiHendrix's Key",  # Please enter key name
+        "0",  # Please press 0 to add key, or remove key by entering its index. Press enter to contiue  # noqa
+        f"{_PEMS / 'JJ.pub'}",  # Please enter path to public key
+        "JanisJoplin's Key",  # Please enter key name
+        "1",  # Please press 0 to add key, or remove key by entering its index. Press enter to contiue  # noqa
+        "",  # Please press 0 to add key, or remove key by entering its index. Press enter to contiue  # noqa
+    ]
+    input_step3 = [  # Configure Online Key
+        f"{_PEMS / '0d9d3d4bad91c455bc03921daa95774576b86625ac45570d0cac025b08e65043.pub'}",  # Please enter path to public key  # noqa
+        "Online Key",  # Please enter a key name
+    ]
+    input_step4 = [  # Sign Metadata
+        "1",  # Please enter signing key index
+        f"{_PEMS / 'JH.ed25519'}",  # Please enter path to encrypted private key  # noqa
+        "1",  # Please enter signing key index
+        f"{_PEMS / 'JJ.ecdsa'}",  # Please enter path to encrypted private key  # noqa
+    ]
+
+    return input_step1, input_step2, input_step3, input_step4
+
+
+@pytest.fixture
 def root() -> Metadata[Root]:
     return Metadata(Root(expires=datetime.now(timezone.utc)))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,7 +148,7 @@ def ceremony_inputs() -> Tuple[List[str], List[str], List[str], List[str]]:
         "0",  # Please press 0 to add key, or remove key by entering its index  # noqa
         f"{_PEMS / 'JH.pub'}",  # Please enter path to public key
         "JimiHendrix's Key",  # Please enter key name
-        "0",  # Please press 0 to add key, or remove key by entering its index. Press enter to contiue  # noqa
+        "0",  # Please press 0 to add key, or remove key by entering its index.  # noqa
         f"{_PEMS / 'JJ.pub'}",  # Please enter path to public key
         "JanisJoplin's Key",  # Please enter key name
         "1",  # Please press 0 to add key, or remove key by entering its index. Press enter to contiue  # noqa

--- a/tests/unit/cli/admin/test_ceremony.py
+++ b/tests/unit/cli/admin/test_ceremony.py
@@ -56,7 +56,7 @@ class TestCeremony:
 
         assert [s["keyid"] for s in sigs_r] == [s["keyid"] for s in sigs_e]
         assert result.data == expected
-        assert "Please enter a positive number above 1" in result.stdout
+        assert "Please enter threshold above 1" in result.stdout
 
     def test_ceremony_non_positive_expiration(
         self, ceremony_inputs, patch_getpass, patch_utcnow

--- a/tests/unit/cli/admin/test_ceremony.py
+++ b/tests/unit/cli/admin/test_ceremony.py
@@ -1,7 +1,7 @@
 import json
 
 from repository_service_tuf.cli.admin import ceremony
-from tests.conftest import _PAYLOADS, invoke_command
+from tests.conftest import _PAYLOADS, _PEMS, invoke_command
 
 
 class TestCeremony:
@@ -21,3 +21,29 @@ class TestCeremony:
 
         assert [s["keyid"] for s in sigs_r] == [s["keyid"] for s in sigs_e]
         assert result.data == expected
+
+    def test_ceremony_online_key_one_of_root_keys(
+        self, ceremony_inputs, patch_getpass, patch_utcnow
+    ):
+        # Test that online key cannot be one of root key's.
+        input_step1, input_step2, _, input_step4 = ceremony_inputs
+        input_step3 = [  # Configure Online Key
+            f"{_PEMS / 'JH.pub'}",  # Please enter path to public key
+            f"{_PEMS / '0d9d3d4bad91c455bc03921daa95774576b86625ac45570d0cac025b08e65043.pub'}",  # Please enter path to public key  # noqa
+            "Online Key",  # Please enter a key name
+        ]
+        result = invoke_command(
+            ceremony.ceremony,
+            input_step1 + input_step2 + input_step3 + input_step4,
+            [],
+        )
+
+        with open(_PAYLOADS / "ceremony.json") as f:
+            expected = json.load(f)
+
+        sigs_r = result.data["metadata"]["root"].pop("signatures")
+        sigs_e = expected["metadata"]["root"].pop("signatures")
+
+        assert [s["keyid"] for s in sigs_r] == [s["keyid"] for s in sigs_e]
+        assert result.data == expected
+        assert "Key already in use." in result.stdout

--- a/tests/unit/cli/admin/test_ceremony.py
+++ b/tests/unit/cli/admin/test_ceremony.py
@@ -22,6 +22,73 @@ class TestCeremony:
         assert [s["keyid"] for s in sigs_r] == [s["keyid"] for s in sigs_e]
         assert result.data == expected
 
+    def test_ceremony_threshold_less_than_2(
+        self, ceremony_inputs, patch_getpass, patch_utcnow
+    ):
+        input_step1, _, input_step3, input_step4 = ceremony_inputs
+        input_step2 = [  # Configure Root Keys
+            "0",  # Please enter root threshold
+            "1",  # Please enter root threshold
+            "2",  # Please enter root threshold
+            f"{_PEMS / 'JC.pub'}",  # Please enter path to public key
+            "my rsa key",  # Please enter key name
+            "0",  # Please press 0 to add key, or remove key by entering its index  # noqa
+            f"{_PEMS / 'JH.pub'}",  # Please enter path to public key
+            "JimiHendrix's Key",  # Please enter key name
+            "0",  # Please press 0 to add key, or remove key by entering its index.  # noqa
+            f"{_PEMS / 'JJ.pub'}",  # Please enter path to public key
+            "JanisJoplin's Key",  # Please enter key name
+            "1",  # Please press 0 to add key, or remove key by entering its index. Press enter to contiue  # noqa
+            "",  # Please press 0 to add key, or remove key by entering its index. Press enter to contiue  # noqa
+        ]
+
+        result = invoke_command(
+            ceremony.ceremony,
+            input_step1 + input_step2 + input_step3 + input_step4,
+            [],
+        )
+
+        with open(_PAYLOADS / "ceremony.json") as f:
+            expected = json.load(f)
+
+        sigs_r = result.data["metadata"]["root"].pop("signatures")
+        sigs_e = expected["metadata"]["root"].pop("signatures")
+
+        assert [s["keyid"] for s in sigs_r] == [s["keyid"] for s in sigs_e]
+        assert result.data == expected
+        assert "Please enter a positive number above 1" in result.stdout
+
+    def test_ceremony_non_positive_expiration(
+        self, ceremony_inputs, patch_getpass, patch_utcnow
+    ):
+        _, input_step2, input_step3, input_step4 = ceremony_inputs
+        input_step1 = [  # Configure online role settings and root expiration
+            "-1",  # Please enter days until expiry for timestamp role (1)
+            "0",  # Please enter days until expiry for timestamp role (1)
+            "",  # Please enter days until expiry for timestamp role (1)
+            "",  # Please enter days until expiry for snapshot role (1)
+            "",  # Please enter days until expiry for targets role (365)
+            "",  # Please enter days until expiry for bins role (1)
+            "4",  # Please enter number of delegated hash bins [2/4/8/16/32/64/128/256/512/1024/2048/4096/8192/16384] (256)  # noqa
+            "",  # Please enter days until expiry for root role (365)
+        ]
+
+        result = invoke_command(
+            ceremony.ceremony,
+            input_step1 + input_step2 + input_step3 + input_step4,
+            [],
+        )
+
+        with open(_PAYLOADS / "ceremony.json") as f:
+            expected = json.load(f)
+
+        sigs_r = result.data["metadata"]["root"].pop("signatures")
+        sigs_e = expected["metadata"]["root"].pop("signatures")
+
+        assert [s["keyid"] for s in sigs_r] == [s["keyid"] for s in sigs_e]
+        assert result.data == expected
+        assert "Please enter a valid positive integer number" in result.stdout
+
     def test_ceremony_online_key_one_of_root_keys(
         self, ceremony_inputs, patch_getpass, patch_utcnow
     ):

--- a/tests/unit/cli/admin/test_ceremony.py
+++ b/tests/unit/cli/admin/test_ceremony.py
@@ -1,38 +1,17 @@
 import json
 
 from repository_service_tuf.cli.admin import ceremony
-from tests.conftest import _PAYLOADS, _PEMS, invoke_command
+from tests.conftest import _PAYLOADS, invoke_command
 
 
 class TestCeremony:
-    def test_ceremony(self, patch_getpass, patch_utcnow):
-        inputs = [
-            "",  # Please enter days until expiry for timestamp role (1)
-            "",  # Please enter days until expiry for snapshot role (1)
-            "",  # Please enter days until expiry for targets role (365)
-            "",  # Please enter days until expiry for bins role (1)
-            "4",  # Please enter number of delegated hash bins [2/4/8/16/32/64/128/256/512/1024/2048/4096/8192/16384] (256)  # noqa
-            "",  # Please enter days until expiry for root role (365)
-            "2",  # Please enter root threshold
-            f"{_PEMS / 'JC.pub'}",  # Please enter path to public key
-            "my rsa key",  # Please enter key name
-            "0",  # Please press 0 to add key, or remove key by entering its index  # noqa
-            f"{_PEMS / 'JH.pub'}",  # Please enter path to public key
-            "JimiHendrix's Key",  # Please enter key name
-            "0",  # Please press 0 to add key, or remove key by entering its index. Press enter to contiue  # noqa
-            f"{_PEMS / 'JJ.pub'}",  # Please enter path to public key
-            "JanisJoplin's Key",  # Please enter key name
-            "1",  # Please press 0 to add key, or remove key by entering its index. Press enter to contiue  # noqa
-            "",  # Please press 0 to add key, or remove key by entering its index. Press enter to contiue  # noqa
-            f"{_PEMS / '0d9d3d4bad91c455bc03921daa95774576b86625ac45570d0cac025b08e65043.pub'}",  # Please enter path to public key  # noqa
-            "Online Key",  # Please enter a key name
-            "1",  # Please enter signing key index
-            f"{_PEMS / 'JH.ed25519'}",  # Please enter path to encrypted private key  # noqa
-            "1",  # Please enter signing key index
-            f"{_PEMS / 'JJ.ecdsa'}",  # Please enter path to encrypted private key  # noqa
-        ]
-
-        result = invoke_command(ceremony.ceremony, inputs, [])
+    def test_ceremony(self, ceremony_inputs, patch_getpass, patch_utcnow):
+        input_step1, input_step2, input_step3, input_step4 = ceremony_inputs
+        result = invoke_command(
+            ceremony.ceremony,
+            input_step1 + input_step2 + input_step3 + input_step4,
+            [],
+        )
 
         with open(_PAYLOADS / "ceremony.json") as f:
             expected = json.load(f)

--- a/tests/unit/cli/admin/test_ceremony.py
+++ b/tests/unit/cli/admin/test_ceremony.py
@@ -119,9 +119,10 @@ class TestCeremony:
         self, ceremony_inputs, patch_getpass, patch_utcnow
     ):
         input_step1, _, input_step3, input_step4 = ceremony_inputs
+        # After setting one key we are trying to continue with pressing "enter"
+        # This wouldn't work as threshold is 2 and its required to set 2 keys.
         input_step2 = [  # Configure Root Keys
             "2",  # Please enter root threshold
-            "0",  # Please press 0 to add key, or remove key by entering its index  # noqa
             f"{_PEMS / 'JH.pub'}",  # Please enter path to public key
             "JimiHendrix's Key",  # Please enter key name
             # Try continuing even though threshold is not reached.
@@ -147,4 +148,4 @@ class TestCeremony:
         assert result.data == expected
         # Asser that at least root_threshold number of public keys are added.
         root_role = result.data["metadata"]["root"]["signed"]["roles"]["root"]
-        assert len(root_role["keyids"]) <= root_role["threshold"]
+        assert len(root_role["keyids"]) == root_role["threshold"]


### PR DESCRIPTION
# Description
<!--- What is the PR about? -->

Add:  
- test we cannot add online key as one of root keys
- requirement that threshold > 2 & add test for that
- test that expiration days must be a positive number

Additionally, improve type annotations in a few places
and move ceremony tests input inside conftest to be reused.

<!--- Please reference the issue(s) this PR fixes. -->
Related to #533

# Additional requirements
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct