### PR TITLE
Support loading a key from HashiCorp Vault in admin cli

### DIFF
--- a/repository_service_tuf/cli/admin/helpers.py
+++ b/repository_service_tuf/cli/admin/helpers.py
@@ -16,7 +16,13 @@ from cryptography.hazmat.primitives.serialization import (
 )
 from rich.prompt import Confirm, IntPrompt, InvalidResponse, Prompt
 from rich.table import Table
-from securesystemslib.signer import CryptoSigner, Key, Signature, SSlibKey
+from securesystemslib.signer import (
+    CryptoSigner,
+    Key,
+    Signature,
+    SSlibKey,
+    VaultSigner,
+)
 from tuf.api.metadata import (
     Metadata,
     Root,
@@ -148,6 +154,15 @@ def _load_key_from_file_prompt() -> Tuple[str, SSlibKey]:
     key = SSlibKey.from_crypto(crypto)
     uri = f"fn:{key.keyid}"
 
+    return uri, key
+
+
+def _load_key_from_hv_prompt() -> Tuple[str, SSlibKey]:
+    """Prompt for HashiCorp Vault key name, return signer uri and Key."""
+    # TODO: Inform user that they need to configure VAULT_ADDR and VAULT_TOKEN
+    hv_key_name = Prompt.ask("Please enter HashiCorp Vault key name")
+
+    uri, key = VaultSigner.import_(hv_key_name)
     return uri, key
 
 

--- a/repository_service_tuf/cli/admin/helpers.py
+++ b/repository_service_tuf/cli/admin/helpers.py
@@ -137,8 +137,8 @@ def _load_signer_from_file_prompt(public_key: SSlibKey) -> CryptoSigner:
     return CryptoSigner(private_key, public_key)
 
 
-def _load_key_from_file_prompt() -> SSlibKey:
-    """Prompt for path to public key, return Key."""
+def _load_key_from_file_prompt() -> Tuple[str, SSlibKey]:
+    """Prompt for path to public key, return signer uri and Key."""
     path = Prompt.ask("Please enter path to public key")
     with open(path, "rb") as f:
         public_pem = f.read()
@@ -146,14 +146,15 @@ def _load_key_from_file_prompt() -> SSlibKey:
     crypto = load_pem_public_key(public_pem)
 
     key = SSlibKey.from_crypto(crypto)
+    uri = f"fn:{key.keyid}"
 
-    return key
+    return uri, key
 
 
 def _load_key_prompt(root: Root) -> Optional[Key]:
     """Prompt and return Key, or None on error or if key is already loaded."""
     try:
-        key = _load_key_from_file_prompt()
+        _, key = _load_key_from_file_prompt()
 
     except (OSError, ValueError) as e:
         console.print(f"Cannot load key: {e}")


### PR DESCRIPTION
Changes key loading helpers used by admin ceremony and metadata update commands to provide an option to the user to load a public key from HashiCorp Vault into TUF metadata.

TODO:
- update to securesystemslib 1.0.0 to use VaultSigner (this will require a major sweep through the code base)
- adopt change in existing metadata update and sign tests (currently, only helper tests are updated)
- add new tests
- re-think "ambient" config needed by HashiCorp client. options are:
  1. tell user to provide config out-of-band, e.g. via rc file, env vars, etc. as expected by securesystemslib
  2. prompt user for config, and re-export in a form supported by securesystemslib

tuf-on-ci does the former (see "Prepare your local environment" in its [docs/ONLINE-SIGNING-SETUP.md](https://github.com/theupdateframework/tuf-on-ci/blob/main/docs/ONLINE-SIGNING-SETUP.md) (cc @jku, who might be willing to share some wisdom )
