### PR TITLE
Add '--dry-run' option for 'ceremony' and 'sign' commands

### DIFF
--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -129,12 +129,19 @@ You can do the Ceremony offline. This means on a disconnected computer
 
     Usage: rstuf admin ceremony [OPTIONS]
 
-    Bootstrap Ceremony to create initial root metadata and RSTUF config.
+    Perform ceremony and send result to API to trigger bootstrap.
+    * If `--out [FILENAME]` is passed, result is written to local FILENAME
+    (in addition to being sent to API).
 
-    ╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────╮
-    │ --out          FILENAME  Write output json result to FILENAME (default: 'ceremony-payload.json')    │
-    │ --help     -h            Show this message and exit.                                                │
-    ╰─────────────────────────────────────────────────────────────────────────────────────────────────────╯
+    * If `--dry-run` is passed, result is not sent to API.
+    You can still pass `--out [FILENAME]` to store the result locally.
+    The `--api-server` admin option and `SERVER` from config will be ignored.
+
+    ╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+    │ --out          FILENAME  Write output json result to FILENAME (default: 'ceremony-payload.json')                                        │
+    │ --dry-run                Run ceremony in dry-run mode without sending result to API. Ignores options and configurations related to API. │
+    │ --help     -h            Show this message and exit.                                                                                    │
+    ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 
 There are four steps in the ceremony.
 
@@ -180,13 +187,18 @@ sign (``sign``)
 
     Usage: rstuf admin metadata sign [OPTIONS]
 
-    Add one signature to root metadata.
+    Perform sign for pending event and send result to API.
+    * If `--in FILENAME` is passed, input is not read from API but from local FILENAME.
+    * If `--out [FILENAME]` is passed, result is written to local FILENAME (in addition to being sent to API).
+    * If `--dry-run` is passed, result is not sent to API. You can still pass `--out [FILENAME]` to store the result locally.
+    * If `--in` and `--dry-run` is passed, `--api-server` admin option and `SERVER` from config will be ignored.
 
-    ╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-    │ --in        FILENAME  Input file containing the JSON response from the 'GET /api/v1/metadata/sign' RSTUF API endpoint.  │
-    │ --out       FILENAME  Write output JSON result to FILENAME (default: 'sign-payload.json')                               │
-    │ --help  -h            Show this message and exit.                                                                       │
-    ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+    ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+    │ --in           FILENAME  Input file containing the JSON response from the 'GET /api/v1/metadata/sign' RSTUF API endpoint.            │
+    │ --out          FILENAME  Write output JSON result to FILENAME (default: 'sign-payload.json')                                         │
+    │ --dry-run                Run sign in dry-run mode without sending result to API. Ignores options and configurations related to API.  │
+    │ --help     -h            Show this message and exit.                                                                                 │
+    ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 
 .. rstuf-cli-admin-send
 

--- a/repository_service_tuf/cli/admin/ceremony.py
+++ b/repository_service_tuf/cli/admin/ceremony.py
@@ -50,10 +50,29 @@ DEFAULT_PATH = "ceremony-payload.json"
     help=f"Write output json result to FILENAME (default: '{DEFAULT_PATH}')",
     type=click.File("w"),
 )
-@click.option("--dry-run", is_flag=True, default=False, help="")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help=(
+        "Run ceremony in dry-run mode without sending result to API. "
+        "Ignores options and configurations related to API."
+    ),
+)
 @click.pass_context
 def ceremony(context: Any, out: Optional[click.File], dry_run: bool) -> None:
-    """Bootstrap Ceremony to create initial root metadata and RSTUF config."""
+    """
+    Perform ceremony and send result to API to trigger bootstrap.
+
+    \b
+    * If `--out [FILENAME]` is passed, result is written to local FILENAME
+    (in addition to being sent to API).
+
+    \b
+    * If `--dry-run` is passed, result is not sent to API.
+    You can still pass `--out [FILENAME]` to store the result locally.
+    The `--api-server` admin option and `SERVER` from config will be ignored.
+    """
     console.print("\n", Markdown("# Metadata Bootstrap Tool"))
     settings = context.obj["settings"]
     # Running online ceremony requires connection to the server and

--- a/repository_service_tuf/cli/admin/ceremony.py
+++ b/repository_service_tuf/cli/admin/ceremony.py
@@ -50,16 +50,18 @@ DEFAULT_PATH = "ceremony-payload.json"
     help=f"Write output json result to FILENAME (default: '{DEFAULT_PATH}')",
     type=click.File("w"),
 )
+@click.option("--dry-run", is_flag=True, default=False, help="")
 @click.pass_context
-def ceremony(context: Any, out: Optional[click.File]) -> None:
+def ceremony(context: Any, out: Optional[click.File], dry_run: bool) -> None:
     """Bootstrap Ceremony to create initial root metadata and RSTUF config."""
     console.print("\n", Markdown("# Metadata Bootstrap Tool"))
     settings = context.obj["settings"]
     # Running online ceremony requires connection to the server and
     # confirmation that the server is indeed ready for bootstap.
-    if not settings.get("SERVER") and not out:
+    if not settings.get("SERVER") and not dry_run:
         raise click.ClickException(
-            "Either '--api-sever'/'SERVER' in RSTUF config or '--out' needed"
+            "Either '--api-sever' admin option/'SERVER' in RSTUF config or "
+            "'--dry-run' needed"
         )
 
     # Performs ceremony steps.
@@ -114,7 +116,7 @@ def ceremony(context: Any, out: Optional[click.File]) -> None:
         json.dump(asdict(bootstrap_payload), out, indent=2)  # type: ignore
         console.print(f"Saved result to '{out.name}'")
 
-    if settings.get("SERVER"):
+    if settings.get("SERVER") and not dry_run:
         task_id = send_payload(
             settings=settings,
             url=URL.BOOTSTRAP.value,

--- a/repository_service_tuf/cli/admin/sign.py
+++ b/repository_service_tuf/cli/admin/sign.py
@@ -83,7 +83,15 @@ DEFAULT_PATH = "sign-payload.json"
     type=click.File("w"),
     required=False,
 )
-@click.option("--dry-run", is_flag=True, default=False, help="")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help=(
+        "Run sign in dry-run mode without sending result to API. "
+        "Ignores options and configurations related to API."
+    ),
+)
 @click.pass_context
 def sign(
     context: click.Context,
@@ -91,7 +99,21 @@ def sign(
     out: Optional[click.File],
     dry_run: bool,
 ) -> None:
-    """Add one signature to root metadata."""
+    """
+    Perform sign for pending event and send result to API.
+
+    * If `--in FILENAME` is passed, input is not read from API but from local
+    FILENAME.
+
+    * If `--out [FILENAME]` is passed, result is written to local FILENAME
+    (in addition to being sent to API).
+
+    * If `--dry-run` is passed, result is not sent to API.
+    You can still pass `--out [FILENAME]` to store the result locally.
+
+    * If `--in` and `--dry-run` is passed, `--api-server` admin option and
+    `SERVER` from config will be ignored.
+    """
     console.print("\n", Markdown("# Metadata Signing Tool"))
     settings = context.obj["settings"]
     # Make sure there is a way to get a DAS metadata for signing.

--- a/repository_service_tuf/cli/admin/sign.py
+++ b/repository_service_tuf/cli/admin/sign.py
@@ -83,18 +83,30 @@ DEFAULT_PATH = "sign-payload.json"
     type=click.File("w"),
     required=False,
 )
+@click.option("--dry-run", is_flag=True, default=False, help="")
 @click.pass_context
 def sign(
     context: click.Context,
     input: Optional[click.File],
     out: Optional[click.File],
+    dry_run: bool,
 ) -> None:
     """Add one signature to root metadata."""
     console.print("\n", Markdown("# Metadata Signing Tool"))
     settings = context.obj["settings"]
+    # Make sure there is a way to get a DAS metadata for signing.
     if settings.get("SERVER") is None and input is None:
         raise click.ClickException(
-            "Either '--api-sever'/'SERVER' in RSTUF config or '--in' needed"
+            "Either '--api-sever' admin option/'SERVER' in RSTUF config or "
+            "'--in' needed"
+        )
+
+    # Make sure user understands that result will be send to the API and if the
+    # the user wants something else should use '--dry-run'.
+    if settings.get("SERVER") is None and not dry_run:
+        raise click.ClickException(
+            "Either '--api-sever' admin option/'SERVER' in RSTUF config or "
+            "'--dry-run' needed"
         )
     ###########################################################################
     # Load roots
@@ -150,7 +162,7 @@ def sign(
         json.dump(asdict(payload), out, indent=2)  # type: ignore
         console.print(f"Saved result to '{out.name}'")
 
-    if settings.get("SERVER"):
+    if settings.get("SERVER") and not dry_run:
         console.print(f"\nSending signature to {settings.SERVER}")
         task_id = send_payload(
             settings,

--- a/tests/unit/cli/admin/test_ceremony.py
+++ b/tests/unit/cli/admin/test_ceremony.py
@@ -308,6 +308,6 @@ class TestCeremonyError:
         result = invoke_command(ceremony.ceremony, [], [], std_err_empty=False)
 
         err_prefix = "Either '--api-sever' admin option/'SERVER'"
-        err_suffix = "in RSTUF config or '--dry-run' needed"
+        err_suffix = "or '--dry-run'"
         assert err_prefix in result.stderr
         assert err_suffix in result.stderr

--- a/tests/unit/cli/admin/test_ceremony.py
+++ b/tests/unit/cli/admin/test_ceremony.py
@@ -7,7 +7,7 @@ from tests.conftest import _HELPERS, _PAYLOADS, _PEMS, invoke_command
 
 
 class TestCeremony:
-    def test_ceremony_with_custom_out(
+    def test_ceremony_with_dry_run_and_custom_out(
         self,
         monkeypatch,
         ceremony_inputs,
@@ -17,7 +17,10 @@ class TestCeremony:
         patch_getpass,
         patch_utcnow,
     ):
-
+        """
+        Test that '--dry-run' and '--out' are compatible without connecting to
+        the API.
+        """
         # public keys and signing keys selection options
         monkeypatch.setattr(f"{_HELPERS}._select", key_selection)
 
@@ -26,7 +29,7 @@ class TestCeremony:
         result = invoke_command(
             ceremony.ceremony,
             input_step1 + input_step2 + input_step3 + input_step4,
-            args=["--out", custom_path],
+            args=["--dry-run", "--out", custom_path],
         )
 
         with open(_PAYLOADS / "ceremony.json") as f:
@@ -37,6 +40,8 @@ class TestCeremony:
 
         assert [s["keyid"] for s in sigs_r] == [s["keyid"] for s in sigs_e]
         assert result.data == expected
+        assert f"Saved result to '{custom_path}'" in result.stdout
+        assert "Bootstrap completed." not in result.stdout
 
     def test_ceremony_threshold_less_than_2(
         self,
@@ -65,7 +70,7 @@ class TestCeremony:
         result = invoke_command(
             ceremony.ceremony,
             input_step1 + input_step2 + input_step3 + input_step4,
-            [],
+            ["--dry-run"],
         )
 
         with open(_PAYLOADS / "ceremony.json") as f:
@@ -103,7 +108,7 @@ class TestCeremony:
         result = invoke_command(
             ceremony.ceremony,
             input_step1 + input_step2 + input_step3 + input_step4,
-            [],
+            ["--dry-run"],
         )
 
         with open(_PAYLOADS / "ceremony.json") as f:
@@ -132,6 +137,7 @@ class TestCeremony:
         monkeypatch.setattr(ceremony, "task_status", fake_task_status)
         input_step1, input_step2, input_step3, input_step4 = ceremony_inputs
         test_context["settings"].SERVER = "http://localhost:80"
+        # public keys and signing keys selection options
         monkeypatch.setattr(f"{_HELPERS}._select", key_selection)
 
         result = invoke_command(
@@ -186,6 +192,7 @@ class TestCeremony:
         input_step1, input_step2, input_step3, input_step4 = ceremony_inputs
         test_context["settings"].SERVER = "http://localhost:80"
         custom_path = "file.json"
+        # public keys and signing keys selection options
         monkeypatch.setattr(f"{_HELPERS}._select", key_selection)
 
         result = invoke_command(
@@ -246,7 +253,7 @@ class TestCeremony:
         result = invoke_command(
             ceremony.ceremony,
             input_step1 + input_step2 + input_step3 + input_step4,
-            [],
+            ["--dry-run"],
         )
 
         with open(_PAYLOADS / "ceremony.json") as f:
@@ -259,20 +266,48 @@ class TestCeremony:
         assert result.data == expected
         assert "Key already in use." in result.stdout
 
+    def test_ceremony_dry_run_with_server_config_set(
+        self,
+        monkeypatch,
+        ceremony_inputs,
+        key_selection,
+        client,
+        test_context,
+        patch_getpass,
+        patch_utcnow,
+    ):
+        """
+        Test that '--dry-run' is with higher priority than 'settings.SERVER'.
+        """
+        # public keys and signing keys selection options
+        monkeypatch.setattr(f"{_HELPERS}._select", key_selection)
+        input_step1, input_step2, input_step3, input_step4 = ceremony_inputs
+        test_context["settings"].SERVER = "http://localhost:80"
+        # We want to test when only "--dry-run" is used we will not save a file
+        # locally and will not send payload to the API.
+        # Given that "invoke_command" always saves a file, so the result can be
+        # read we cannot use it.
+        with client.isolated_filesystem():
+            result = client.invoke(
+                ceremony.ceremony,
+                args=["--dry-run"],
+                input="\n".join(
+                    input_step1 + input_step2 + input_step3 + input_step4
+                ),
+                obj=test_context,
+                catch_exceptions=False,
+            )
+
+        assert result.stderr == ""
+        assert "Saved result to " not in result.stdout
+        assert "Bootstrap completed." not in result.stdout
+
 
 class TestCeremonyError:
-    def test_ceremony_no_api_server_and_no_output_option(
-        self, client, test_context, ceremony_inputs
-    ):
-        input_step1, input_step2, input_step3, input_step4 = ceremony_inputs
-        result = client.invoke(
-            ceremony.ceremony,
-            args=[],
-            input="\n".join(
-                input_step1 + input_step2 + input_step3 + input_step4
-            ),
-            obj=test_context,
-            catch_exceptions=False,
-        )
+    def test_ceremony_no_api_server_and_no_dry_run_option(self):
+        result = invoke_command(ceremony.ceremony, [], [], std_err_empty=False)
 
-        assert "Either '--api-sever'/'SERVER'" in result.stderr
+        err_prefix = "Either '--api-sever' admin option/'SERVER'"
+        err_suffix = "in RSTUF config or '--dry-run' needed"
+        assert err_prefix in result.stderr
+        assert err_suffix in result.stderr

--- a/tests/unit/cli/admin/test_sign.py
+++ b/tests/unit/cli/admin/test_sign.py
@@ -271,7 +271,7 @@ class TestSignError:
         result = invoke_command(sign.sign, [], [], std_err_empty=False)
 
         err_prefix = "Either '--api-sever' admin option/'SERVER'"
-        err_suffix = "in RSTUF config or '--in' needed"
+        err_suffix = "or '--in'"
         assert err_prefix in result.stderr
         assert err_suffix in result.stderr
 
@@ -282,7 +282,7 @@ class TestSignError:
         result = invoke_command(sign.sign, [], args, std_err_empty=False)
 
         err_prefix = "Either '--api-sever' admin option/'SERVER'"
-        err_suffix = "in RSTUF config or '--dry-run'"
+        err_suffix = "or '--dry-run'"
         assert err_prefix in result.stderr
         assert err_suffix in result.stderr
 


### PR DESCRIPTION
# Description
The '--dry-run' option scope is regarding the command output.
This means that when the option is used it will not influence the
input options.
Instead, it will directly interfere with the output. If '--dry-run'
is used, then the CLI will ignore both '--api-server' admin option
and the RSTUF configuration file and its corresponding SERVER option.

Signed-off-by: Martin Vrachev <martin.vrachev@broadcom.com>


<!--- Please reference the issue(s) this PR fixes. -->
Related to #533.


# Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct