### PR TITLE
fix: explicity output (graceful) when no signing

### DIFF
--- a/repository_service_tuf/cli/admin/sign.py
+++ b/repository_service_tuf/cli/admin/sign.py
@@ -36,10 +36,7 @@ from repository_service_tuf.helpers.api_client import (
 
 
 def _parse_pending_data(pending_roles_resp: Dict[str, Any]) -> Dict[str, Any]:
-    data = pending_roles_resp.get("data")
-    if data is None:
-        error = "'data' field missing from api server response/file input"
-        raise click.ClickException(error)
+    data = pending_roles_resp.get("data", {})
 
     pending_roles: Dict[str, Dict[str, Any]] = data.get("metadata", {})
     if len(pending_roles) == 0:

--- a/tests/unit/cli/admin/test_sign.py
+++ b/tests/unit/cli/admin/test_sign.py
@@ -370,13 +370,6 @@ class TestHelpers:
 
         assert "No metadata available for signing" in str(e)
 
-    def test__parse_pending_data_missing_data(self):
-        with pytest.raises(click.ClickException) as e:
-            sign._parse_pending_data({})
-
-        err = "'data' field missing from api server response/file input"
-        assert err in str(e)
-
     def test__get_pending_roles_request(self, monkeypatch):
         fake_settings = pretend.stub(SERVER=None)
         fake_json = pretend.stub()


### PR DESCRIPTION
# Description

This commit adds a more user-friendly output when no metadata is available for signing.

"No metadata available for signing"

# Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct