### PR TITLE
feat: Support headers for admin `rstuf admin -H`

### DIFF
--- a/docs/source/devel/repository_service_tuf.cli.admin.delegations.rst
+++ b/docs/source/devel/repository_service_tuf.cli.admin.delegations.rst
@@ -1,0 +1,29 @@
+repository\_service\_tuf.cli.admin.delegations package
+======================================================
+
+Submodules
+----------
+
+repository\_service\_tuf.cli.admin.delegations.delete module
+------------------------------------------------------------
+
+.. automodule:: repository_service_tuf.cli.admin.delegations.delete
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+repository\_service\_tuf.cli.admin.delegations.new module
+---------------------------------------------------------
+
+.. automodule:: repository_service_tuf.cli.admin.delegations.new
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: repository_service_tuf.cli.admin.delegations
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/devel/repository_service_tuf.cli.admin.metadata.rst
+++ b/docs/source/devel/repository_service_tuf.cli.admin.metadata.rst
@@ -1,0 +1,29 @@
+repository\_service\_tuf.cli.admin.metadata package
+===================================================
+
+Submodules
+----------
+
+repository\_service\_tuf.cli.admin.metadata.sign module
+-------------------------------------------------------
+
+.. automodule:: repository_service_tuf.cli.admin.metadata.sign
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+repository\_service\_tuf.cli.admin.metadata.update module
+---------------------------------------------------------
+
+.. automodule:: repository_service_tuf.cli.admin.metadata.update
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: repository_service_tuf.cli.admin.metadata
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/devel/repository_service_tuf.cli.admin.rst
+++ b/docs/source/devel/repository_service_tuf.cli.admin.rst
@@ -7,6 +7,8 @@ Subpackages
 .. toctree::
    :maxdepth: 4
 
+   repository_service_tuf.cli.admin.delegations
+   repository_service_tuf.cli.admin.metadata
    repository_service_tuf.cli.admin.send
 
 Submodules
@@ -32,22 +34,6 @@ repository\_service\_tuf.cli.admin.import\_artifacts module
 -----------------------------------------------------------
 
 .. automodule:: repository_service_tuf.cli.admin.import_artifacts
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-repository\_service\_tuf.cli.admin.sign module
-----------------------------------------------
-
-.. automodule:: repository_service_tuf.cli.admin.sign
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-repository\_service\_tuf.cli.admin.update module
-------------------------------------------------
-
-.. automodule:: repository_service_tuf.cli.admin.update
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -93,6 +93,8 @@ It executes administrative commands to the Repository Service for TUF.
 
     ╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
     │ --api-server      TEXT  URL to an RSTUF API.                                                                               │
+    │ --headers     -H  TEXT  Headers to include in the request. Example: 'Authorization: Bearer <token>, Content-Type:          │
+    │                         application/json'                                                                                  │
     │ --help        -h        Show this message and exit.                                                                        │
     ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
     ╭─ Commands ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮

--- a/repository_service_tuf/cli/admin/__init__.py
+++ b/repository_service_tuf/cli/admin/__init__.py
@@ -13,11 +13,22 @@ from typing import Optional
 from repository_service_tuf.cli import click, rstuf
 
 
-def _set_settings(context: click.Context, api_server: Optional[str]):
+def _set_settings(
+    context: click.Context, api_server: Optional[str], headers: Optional[str]
+):
     """Set context.obj['settings'] attributes."""
     settings = context.obj["settings"]
     if api_server:
         settings.SERVER = api_server
+    if headers:
+        settings.HEADERS = dict(
+            (key.strip(), value.strip())
+            for key, value in (
+                header.split(":", 1) for header in headers.split(",")
+            )
+        )
+    else:
+        settings.HEADERS = None
 
 
 @rstuf.group()  # type: ignore
@@ -26,11 +37,23 @@ def _set_settings(context: click.Context, api_server: Optional[str]):
     help="URL to an RSTUF API.",
     required=False,
 )
+@click.option(
+    "--headers",
+    "-H",
+    help=(
+        "Headers to include in the request. "
+        "Example: 'Authorization: Bearer <token>, "
+        "Content-Type: application/json'"
+    ),
+    required=False,
+)
 @click.pass_context
-def admin(context: click.Context, api_server: Optional[str]):
+def admin(
+    context: click.Context, api_server: Optional[str], headers: Optional[str]
+):
     """Administrative Commands"""
     # Because of tests it has to be in a separate function.
-    _set_settings(context, api_server)  # pragma: no cover
+    _set_settings(context, api_server, headers)  # pragma: no cover
 
 
 @admin.group()

--- a/repository_service_tuf/cli/admin/__init__.py
+++ b/repository_service_tuf/cli/admin/__init__.py
@@ -12,6 +12,10 @@ from typing import Optional
 
 from repository_service_tuf.cli import click, rstuf
 
+HEADERS_EXAMPLE = (
+    "'Authorization: Bearer <token>, Content-Type: application/json'"
+)
+
 
 def _set_settings(
     context: click.Context, api_server: Optional[str], headers: Optional[str]
@@ -21,12 +25,17 @@ def _set_settings(
     if api_server:
         settings.SERVER = api_server
     if headers:
-        settings.HEADERS = dict(
-            (key.strip(), value.strip())
-            for key, value in (
-                header.split(":", 1) for header in headers.split(",")
+        try:
+            settings.HEADERS = dict(
+                (key.strip(), value.strip())
+                for key, value in (
+                    header.split(":", 1) for header in headers.split(",")
+                )
             )
-        )
+        except ValueError:
+            raise click.ClickException(
+                f"Invalid headers format. Example: {HEADERS_EXAMPLE}"
+            )
     else:
         settings.HEADERS = None
 
@@ -40,11 +49,7 @@ def _set_settings(
 @click.option(
     "--headers",
     "-H",
-    help=(
-        "Headers to include in the request. "
-        "Example: 'Authorization: Bearer <token>, "
-        "Content-Type: application/json'"
-    ),
+    help=("Headers to include in the request. " f"Example: {HEADERS_EXAMPLE}"),
     required=False,
 )
 @click.pass_context

--- a/repository_service_tuf/cli/admin/delegations/new.py
+++ b/repository_service_tuf/cli/admin/delegations/new.py
@@ -42,7 +42,10 @@ def _parse_pending_data(pending_roles_resp: Dict[str, Any]) -> Dict[str, Any]:
 def _get_pending_roles(settings: Any) -> Dict[str, Dict[str, Any]]:
     """Get dictionary of pending roles for signing."""
     response = request_server(
-        settings.SERVER, URL.METADATA_SIGN.value, Methods.GET
+        settings.SERVER,
+        URL.METADATA_SIGN.value,
+        Methods.GET,
+        headers=settings.HEADERS,
     )
     if response.status_code != 200:
         raise click.ClickException(

--- a/repository_service_tuf/cli/admin/metadata/sign.py
+++ b/repository_service_tuf/cli/admin/metadata/sign.py
@@ -52,7 +52,10 @@ def _parse_pending_data(pending_roles_resp: Dict[str, Any]) -> Dict[str, Any]:
 def _get_pending_roles(settings: Any) -> Dict[str, Dict[str, Any]]:
     """Get dictionary of pending roles for signing."""
     response = request_server(
-        settings.SERVER, URL.METADATA_SIGN.value, Methods.GET
+        settings.SERVER,
+        URL.METADATA_SIGN.value,
+        Methods.GET,
+        headers=settings.HEADERS,
     )
     if response.status_code != 200:
         raise click.ClickException(

--- a/repository_service_tuf/helpers/api_client.py
+++ b/repository_service_tuf/helpers/api_client.py
@@ -81,7 +81,10 @@ def request_server(
 
 def bootstrap_status(settings: LazySettings) -> Dict[str, Any]:
     response = request_server(
-        settings.SERVER, URL.BOOTSTRAP.value, Methods.GET
+        settings.SERVER,
+        URL.BOOTSTRAP.value,
+        Methods.GET,
+        headers=settings.HEADERS,
     )
     if response.status_code == 404:
         raise click.ClickException(
@@ -111,6 +114,7 @@ def task_status(
             settings.SERVER,
             f"{URL.TASK.value}{task_id}",
             Methods.GET,
+            headers=settings.HEADERS,
         )
 
         if state_response.status_code != 200:
@@ -171,6 +175,7 @@ def publish_artifacts(settings: LazySettings) -> str:
         settings.SERVER,
         URL.PUBLISH_ARTIFACTS.value,
         Methods.POST,
+        headers=settings.HEADERS,
     )
     if publish_artifacts.status_code != 202:
         raise click.ClickException(
@@ -208,6 +213,7 @@ def send_payload(
         url,
         Methods.POST,
         payload,
+        headers=settings.HEADERS,
     )
 
     if response.status_code != expected_status_code:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,7 @@ _PROMPT_TOOLKIT = "prompt_toolkit.prompt"
 def _create_test_context() -> Dict[str, Any]:
     setting_file = os.path.join(TemporaryDirectory().name, "test_settings.yml")
     test_settings = Dynaconf(settings_files=[setting_file])
+    test_settings.HEADERS = None
     return {"settings": test_settings, "config": setting_file}
 
 

--- a/tests/unit/cli/admin/test_admin.py
+++ b/tests/unit/cli/admin/test_admin.py
@@ -1,4 +1,6 @@
 import pretend
+import pytest
+from click import ClickException
 
 from repository_service_tuf.cli.admin import _set_settings
 
@@ -32,3 +34,18 @@ class TestAdmin:
             "apikey": "1234",
             "Content-Type": "application/json",
         }
+
+    def test_admin__set_settings_api_server_with_bad_headers(self):
+        api_server = "http://localhost:80"
+        fake_settings = pretend.stub(SERVER=None)
+        context = pretend.stub(obj={"settings": fake_settings})
+
+        with pytest.raises(ClickException) as err:
+            _set_settings(
+                context,
+                api_server,
+                headers="apikey1234, Content-Type: application/json",
+            )
+
+        assert context.obj["settings"].SERVER == api_server
+        assert "Invalid headers format" in str(err.value)

--- a/tests/unit/cli/admin/test_admin.py
+++ b/tests/unit/cli/admin/test_admin.py
@@ -8,6 +8,27 @@ class TestAdmin:
         api_server = "http://localhost:80"
         fake_settings = pretend.stub(SERVER=None)
         context = pretend.stub(obj={"settings": fake_settings})
-        _set_settings(context, api_server)
+        _set_settings(
+            context,
+            api_server,
+            headers=None,
+        )
 
         assert context.obj["settings"].SERVER == api_server
+        assert context.obj["settings"].HEADERS is None
+
+    def test_admin__set_settings_api_server_with_headers(self):
+        api_server = "http://localhost:80"
+        fake_settings = pretend.stub(SERVER=None)
+        context = pretend.stub(obj={"settings": fake_settings})
+        _set_settings(
+            context,
+            api_server,
+            headers="apikey: 1234, Content-Type: application/json",
+        )
+
+        assert context.obj["settings"].SERVER == api_server
+        assert context.obj["settings"].HEADERS == {
+            "apikey": "1234",
+            "Content-Type": "application/json",
+        }

--- a/tests/unit/cli/admin/test_sign.py
+++ b/tests/unit/cli/admin/test_sign.py
@@ -42,6 +42,7 @@ class TestSign:
         sign.task_status = pretend.call_recorder(lambda *a: "OK")
         api_server = "http://127.0.0.1"
         test_context["settings"].SERVER = api_server
+        test_context["settings"].HEADERS = None
 
         result = invoke_command(sign.sign, inputs, [], test_context)
 
@@ -54,7 +55,9 @@ class TestSign:
         )
         assert "Metadata Signed and sent to the API! 🔑" in result.stdout
         assert sign.request_server.calls == [
-            pretend.call(api_server, "api/v1/metadata/sign/", Methods.GET)
+            pretend.call(
+                api_server, "api/v1/metadata/sign/", Methods.GET, headers=None
+            )
         ]
         assert sign.send_payload.calls == [
             pretend.call(
@@ -126,7 +129,9 @@ class TestSign:
         assert result.data["signature"]["keyid"] == expected["keyid"]
         assert "Metadata Signed and sent to the API! 🔑" in result.stdout
         assert sign.request_server.calls == [
-            pretend.call(api_server, "api/v1/metadata/sign/", Methods.GET)
+            pretend.call(
+                api_server, "api/v1/metadata/sign/", Methods.GET, headers=None
+            )
         ]
         assert sign.send_payload.calls == [
             pretend.call(
@@ -352,7 +357,9 @@ class TestSignError:
         assert test_result.exit_code == 1, test_result.stdout
         assert "Previous root v1 needed to sign root v2" in test_result.output
         assert sign.request_server.calls == [
-            pretend.call(api_server, "api/v1/metadata/sign/", Methods.GET)
+            pretend.call(
+                api_server, "api/v1/metadata/sign/", Methods.GET, headers=None
+            )
         ]
 
     def test_sign_fully_signed_metadata(
@@ -394,7 +401,9 @@ class TestSignError:
         assert test_result.exit_code == 1, test_result.stdout
         assert "Metadata already fully signed." in test_result.output
         assert sign.request_server.calls == [
-            pretend.call(api_server, "api/v1/metadata/sign/", Methods.GET)
+            pretend.call(
+                api_server, "api/v1/metadata/sign/", Methods.GET, headers=None
+            )
         ]
 
 
@@ -412,7 +421,7 @@ class TestHelpers:
         assert "No metadata available for signing" in str(e)
 
     def test__get_pending_roles_request(self, monkeypatch):
-        fake_settings = pretend.stub(SERVER=None)
+        fake_settings = pretend.stub(SERVER=None, HEADERS=None)
         fake_json = pretend.stub()
         response = pretend.stub(
             status_code=200, json=pretend.call_recorder(lambda: fake_json)
@@ -433,6 +442,7 @@ class TestHelpers:
                 fake_settings.SERVER,
                 sign.URL.METADATA_SIGN.value,
                 sign.Methods.GET,
+                headers=None,
             )
         ]
         assert response.json.calls == [pretend.call()]
@@ -440,7 +450,7 @@ class TestHelpers:
 
     def test__get_pending_roles_request_bad_status_code(self):
         fake_settings = pretend.stub(
-            SERVER="http://localhost:80",
+            SERVER="http://localhost:80", HEADERS=None
         )
         response = pretend.stub(status_code=400, text="")
         sign.request_server = pretend.call_recorder(lambda *a, **kw: response)
@@ -453,5 +463,6 @@ class TestHelpers:
                 fake_settings.SERVER,
                 sign.URL.METADATA_SIGN.value,
                 sign.Methods.GET,
+                headers=None,
             )
         ]

--- a/tests/unit/helpers/test_api_client.py
+++ b/tests/unit/helpers/test_api_client.py
@@ -119,6 +119,7 @@ class TestAPIClient:
                 test_context["settings"].SERVER,
                 api_client.URL.BOOTSTRAP.value,
                 api_client.Methods.GET,
+                headers=None,
             )
         ]
 
@@ -141,6 +142,7 @@ class TestAPIClient:
                 test_context["settings"].SERVER,
                 api_client.URL.BOOTSTRAP.value,
                 api_client.Methods.GET,
+                headers=None,
             )
         ]
 
@@ -163,6 +165,7 @@ class TestAPIClient:
                 test_context["settings"].SERVER,
                 api_client.URL.BOOTSTRAP.value,
                 api_client.Methods.GET,
+                headers=None,
             )
         ]
 
@@ -184,6 +187,7 @@ class TestAPIClient:
                 test_context["settings"].SERVER,
                 api_client.URL.BOOTSTRAP.value,
                 api_client.Methods.GET,
+                headers=None,
             )
         ]
 
@@ -220,21 +224,25 @@ class TestAPIClient:
                 "http://server",
                 "api/v1/task/?task_id=task_id",
                 api_client.Methods.GET,
+                headers=None,
             ),
             pretend.call(
                 "http://server",
                 "api/v1/task/?task_id=task_id",
                 api_client.Methods.GET,
+                headers=None,
             ),
             pretend.call(
                 "http://server",
                 "api/v1/task/?task_id=task_id",
                 api_client.Methods.GET,
+                headers=None,
             ),
             pretend.call(
                 "http://server",
                 "api/v1/task/?task_id=task_id",
                 api_client.Methods.GET,
+                headers=None,
             ),
         ]
 
@@ -272,6 +280,7 @@ class TestAPIClient:
                 status_code=200,
                 json=fake_json,
                 text="{'data': {'state': 'FAILURE', 'k': 'v'}",
+                headers=None,
             )
         )
 
@@ -287,16 +296,19 @@ class TestAPIClient:
                 "http://server",
                 "api/v1/task/?task_id=task_id",
                 api_client.Methods.GET,
+                headers=None,
             ),
             pretend.call(
                 "http://server",
                 "api/v1/task/?task_id=task_id",
                 api_client.Methods.GET,
+                headers=None,
             ),
             pretend.call(
                 "http://server",
                 "api/v1/task/?task_id=task_id",
                 api_client.Methods.GET,
+                headers=None,
             ),
         ]
 
@@ -320,6 +332,7 @@ class TestAPIClient:
                 status_code=200,
                 json=fake_json,
                 text="{'data': {'state': 'ERRORED', 'k': 'v'}",
+                headers=None,
             )
         )
 
@@ -334,16 +347,19 @@ class TestAPIClient:
                 "http://server",
                 "api/v1/task/?task_id=task_id",
                 api_client.Methods.GET,
+                headers=None,
             ),
             pretend.call(
                 "http://server",
                 "api/v1/task/?task_id=task_id",
                 api_client.Methods.GET,
+                headers=None,
             ),
             pretend.call(
                 "http://server",
                 "api/v1/task/?task_id=task_id",
                 api_client.Methods.GET,
+                headers=None,
             ),
         ]
 
@@ -369,6 +385,7 @@ class TestAPIClient:
                 "http://server",
                 "api/v1/task/?task_id=task_id",
                 api_client.Methods.GET,
+                headers=None,
             ),
         ]
 
@@ -393,6 +410,7 @@ class TestAPIClient:
                 "http://server",
                 "api/v1/task/?task_id=task_id",
                 api_client.Methods.GET,
+                headers=None,
             ),
         ]
 
@@ -417,6 +435,7 @@ class TestAPIClient:
                 "http://server",
                 "api/v1/task/?task_id=task_id",
                 api_client.Methods.GET,
+                headers=None,
             ),
         ]
 
@@ -456,16 +475,19 @@ class TestAPIClient:
                 "http://server",
                 "api/v1/task/?task_id=task_id",
                 api_client.Methods.GET,
+                headers=None,
             ),
             pretend.call(
                 "http://server",
                 "api/v1/task/?task_id=task_id",
                 api_client.Methods.GET,
+                headers=None,
             ),
             pretend.call(
                 "http://server",
                 "api/v1/task/?task_id=task_id",
                 api_client.Methods.GET,
+                headers=None,
             ),
         ]
 
@@ -488,6 +510,7 @@ class TestAPIClient:
                 test_context["settings"].SERVER,
                 api_client.URL.PUBLISH_ARTIFACTS.value,
                 api_client.Methods.POST,
+                headers=None,
             )
         ]
 
@@ -510,6 +533,7 @@ class TestAPIClient:
                 test_context["settings"].SERVER,
                 api_client.URL.PUBLISH_ARTIFACTS.value,
                 api_client.Methods.POST,
+                headers=None,
             )
         ]
 
@@ -542,6 +566,7 @@ class TestAPIClient:
                 api_client.URL.BOOTSTRAP.value,
                 api_client.Methods.POST,
                 {"payload": "data"},
+                headers=None,
             )
         ]
 
@@ -578,6 +603,7 @@ class TestAPIClient:
                 api_client.URL.BOOTSTRAP.value,
                 api_client.Methods.POST,
                 {"payload": "data"},
+                headers=None,
             )
         ]
 
@@ -613,6 +639,7 @@ class TestAPIClient:
                 api_client.URL.BOOTSTRAP.value,
                 api_client.Methods.POST,
                 {"payload": "data"},
+                headers=None,
             )
         ]
 
@@ -649,6 +676,7 @@ class TestAPIClient:
                 api_client.URL.BOOTSTRAP.value,
                 api_client.Methods.POST,
                 {"payload": "data"},
+                headers=None,
             )
         ]
 
@@ -685,5 +713,6 @@ class TestAPIClient:
                 api_client.URL.BOOTSTRAP.value,
                 api_client.Methods.POST,
                 {"payload": "data"},
+                headers=None,
             )
         ]


### PR DESCRIPTION
# Description
Feature to support sending headers (HTTP) while using rstuf admin command.

RSTUF might be deployed behind a API Gateway or some authentication layer that requires a token or API Key or specific headers.

This feature enables users to pass headers using `--headers/-H` parameter.

This feature can be compared with `curl -H`

It supports headers such as `apikey: somekey,  Content-Type: application/json'` for example.

Examples:
```bash
rstuf admin --api-server http://api.dev.rstuf.org -H 'apikey: mykey' ceremony
```

```bash
rstuf admin --api-server http://api.dev.rstuf.org -H $TOKEN metadata sign
```


<!--- Please reference the issue(s) this PR fixes. -->
Fixes #(issue)


# Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct