### PR TITLE
fix: crash uncrypted private key

### DIFF
--- a/tests/unit/cli/admin/test_helpers.py
+++ b/tests/unit/cli/admin/test_helpers.py
@@ -66,6 +66,14 @@ class TestHelpers:
             with pytest.raises(ValueError):
                 signer = helpers._load_signer_from_file_prompt(ed25519_key)
 
+        # give key without password and good key after
+        inputs = [
+            f"{_PEMS / '0d9d3d4bad91c455bc03921daa95774576b86625ac45570d0cac025b08e65043'}",  # noqa
+            f"{_PEMS / 'JH.ed25519'}",
+        ]
+        with patch(_PROMPT_TOOLKIT, side_effect=inputs):
+            signer = helpers._load_signer_from_file_prompt(ed25519_key)
+
         # fail with bad password
         fake_click.prompt = pretend.call_recorder(lambda *a, **kw: "hunter1")
         monkeypatch.setattr(f"{_HELPERS}.click", fake_click)


### PR DESCRIPTION
# Description
- do not crash if user gives a unecrypted key asking for the key again
- fix formatting for loading the private key

<!--- Please reference the issue(s) this PR fixes. -->
Fixes #814 
Fixes #789


# Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct