### PR TITLE
fix and improve `rstuf artifact` command

### DIFF
--- a/repository_service_tuf/cli/artifact/delete.py
+++ b/repository_service_tuf/cli/artifact/delete.py
@@ -3,9 +3,14 @@
 from typing import Optional
 
 from click import Context
-from rich import print_json, prompt
+from rich import print_json
 
-from repository_service_tuf.cli import click, console
+from repository_service_tuf.cli import (
+    HEADERS_EXAMPLE,
+    _set_settings,
+    click,
+    console,
+)
 from repository_service_tuf.cli.artifact import artifact
 from repository_service_tuf.helpers.api_client import URL, send_payload
 from repository_service_tuf.helpers.cli import (
@@ -15,32 +20,25 @@ from repository_service_tuf.helpers.cli import (
 
 @artifact.command()
 @click.argument(
-    "filepath",
-    type=click.Path(exists=True),
-    # Currently, this is required. If we support adding artifacts without
-    # giving the filepath then we need to set it to `False` and implement our
-    # own validation to check whether the argument is needed based on the
-    # passed user options.
+    "path",
     required=True,
-)
-@click.option(
-    "-p",
-    "--path",
-    help="A custom path (`TARGETPATH`) for the file, defined in the metadata.",
-    type=str,
-    required=False,
-    default=None,
 )
 @click.option(
     "--api-server",
     help="URL to an RSTUF API.",
     required=False,
 )
+@click.option(
+    "--headers",
+    "-H",
+    help=("Headers to include in the request. " f"Example: {HEADERS_EXAMPLE}"),
+    required=False,
+)
 @click.pass_context
 def delete(
     context: Context,
-    filepath: str,
-    path: Optional[str],
+    path: str,
+    headers: Optional[str],
     api_server: Optional[str],
 ) -> None:
     """
@@ -50,17 +48,18 @@ def delete(
     is carried out.
     """
 
-    settings = context.obj.get("settings")
+    settings = _set_settings(context, api_server, headers)
+
     if api_server:
         settings.SERVER = api_server
 
     if settings.get("SERVER") is None:
-        api_server = prompt.Prompt.ask("\n[cyan]API[/] URL address")
-        settings.SERVER = api_server
+        raise click.ClickException(
+            "Requires '--api-server' "
+            "Example: --api-server https://api.rstuf.example.com"
+        )
 
-    payload = create_artifact_delete_payload_from_filepath(
-        filepath=filepath, path=path
-    )
+    payload = create_artifact_delete_payload_from_filepath(path=path)
 
     task_id = send_payload(
         settings=settings,

--- a/repository_service_tuf/cli/artifact/delete.py
+++ b/repository_service_tuf/cli/artifact/delete.py
@@ -45,7 +45,9 @@ def delete(
     Delete artifacts to the TUF metadata.
 
     A POST /api/v1/artifacts/delete request to the RSTUF API service
-    is carried out.
+    is carried out, where:
+
+    - `PATH` is artifact path to be deleted as stored in the TUF metadata.
     """
 
     settings = _set_settings(context, api_server, headers)

--- a/repository_service_tuf/cli/artifact/repository.py
+++ b/repository_service_tuf/cli/artifact/repository.py
@@ -67,7 +67,7 @@ def _load_root_from_url(root: str) -> bytes:  # pragma: no cover
     # Validate URL scheme
     if not parsed_url.scheme:
         raise click.ClickException(
-            "Please use http://" " or https:// for artifact URL"
+            "Please use http:// or https:// for artifact URL"
         )
 
     # Fetch the file from the local server

--- a/repository_service_tuf/cli/artifact/repository.py
+++ b/repository_service_tuf/cli/artifact/repository.py
@@ -76,7 +76,7 @@ def _load_root_from_url(root: str) -> bytes:  # pragma: no cover
     # Raise an error if the request failed
     response.raise_for_status()
 
-    # Simulate opening a file using StringIO
+    # Open a file using StringIO
     with io.StringIO(response.text) as file:
         content = file.read()
 

--- a/repository_service_tuf/helpers/cli.py
+++ b/repository_service_tuf/helpers/cli.py
@@ -116,18 +116,11 @@ def create_artifact_add_payload_from_filepath(
     return payload.to_dict()
 
 
-def create_artifact_delete_payload_from_filepath(
-    filepath: str, path: Optional[str]
-) -> Dict[str, Any]:
+def create_artifact_delete_payload_from_filepath(path: str) -> Dict[str, Any]:
     """
     Create the payload for the API request of `POST api/v1/artifacts/delete`.
     """
 
-    if path:
-        payload_path = f"{path.rstrip('/')}/{filepath.split('/')[-1]}"
-    else:
-        payload_path = f"{filepath.split('/')[-1]}"
-
-    payload = DeletePayload(artifacts=[payload_path])
+    payload = DeletePayload(artifacts=[path])
 
     return payload.to_dict()

--- a/tests/unit/cli/artifact/test_delete.py
+++ b/tests/unit/cli/artifact/test_delete.py
@@ -19,8 +19,6 @@ class TestDeleteArtifactInteraction:
         path = "artifact/path"
 
         input = [
-            artifact_path,
-            "--path",
             path,
             "--api-server",
             "fake-server",
@@ -44,7 +42,7 @@ class TestDeleteArtifactInteraction:
                 url=URL.ARTIFACTS_DELETE.value,
                 payload={
                     "artifacts": [
-                        f"{path}/{artifact_path}",
+                        path,
                     ],
                 },
                 expected_msg="Remove Artifact(s) successfully submitted.",
@@ -97,86 +95,17 @@ class TestDeleteArtifactInteraction:
         Test that the delete artifact command works as expected given the
         expected arguments/options in the CLI.
         """
-        settings = test_context["settings"]
-        settings.SERVER = "fake-server"
-
-        artifact_path = "dummy-artifact"
         path = "artifact/path"
 
-        input = [
-            artifact_path,
-            "--path",
-            path,
-        ]
+        input = [path]
 
         delete.send_payload = pretend.call_recorder(lambda *a, **kw: "123")
 
-        with client.isolated_filesystem():
-            with open(artifact_path, "w") as f:
-                f.write("Dummy Artifact")
+        result = client.invoke(delete.delete, input, obj=test_context)
 
-            result = client.invoke(delete.delete, input, obj=test_context)
-
-        assert result.exit_code == 0, result.output
-        assert "Successfully submitted task" in result.output
-        assert "RSTUF task ID" in result.output
-
-        assert delete.send_payload.calls == [
-            pretend.call(
-                settings=settings,
-                url=URL.ARTIFACTS_DELETE.value,
-                payload={
-                    "artifacts": [
-                        f"{path}/{artifact_path}",
-                    ],
-                },
-                expected_msg="Remove Artifact(s) successfully submitted.",
-                command_name="Artifact Deletion",
-            )
-        ]
-
-    def test_delete_with_api_server_as_input(self, client, test_context):
-        """
-        Test that the delete artifact command works as expected given the
-        expected arguments/options in the CLI.
-        """
-        artifact_path = "dummy-artifact"
-        path = "artifact/path"
-        prompt_api_server_input = "fake-server"
-
-        options_input = [
-            artifact_path,
-            "--path",
-            path,
-        ]
-
-        delete.send_payload = pretend.call_recorder(lambda *a, **kw: "123")
-
-        with client.isolated_filesystem():
-            with open(artifact_path, "w") as f:
-                f.write("Dummy Artifact")
-
-            result = client.invoke(
-                delete.delete,
-                options_input,
-                input=prompt_api_server_input,
-                obj=test_context,
-            )
-
-        assert result.exit_code == 0, result.output
-        assert "Successfully submitted task" in result.output
-        assert "RSTUF task ID" in result.output
-
-        assert delete.send_payload.calls == [
-            pretend.call(
-                settings=test_context["settings"],
-                url=URL.ARTIFACTS_DELETE.value,
-                payload={
-                    "artifacts": [
-                        f"{path}/{artifact_path}",
-                    ],
-                },
-                expected_msg="Remove Artifact(s) successfully submitted.",
-                command_name="Artifact Deletion",
-            )
-        ]
+        assert result.exit_code == 1, result.output
+        assert (
+            "Requires '--api-server' "
+            "Example: --api-server https://api.rstuf.example.com"
+            in result.stderr
+        )

--- a/tests/unit/helpers/test_cli.py
+++ b/tests/unit/helpers/test_cli.py
@@ -89,42 +89,17 @@ class TestCLIHelpers:
 
     def test_create_artifact_delete_payload_from_filepath(
         self,
-        temp_file: str,
     ) -> None:
         """
         Test that the artifact payload is created correctly given the
         filepath of the artifact
         """
 
-        path = "/fake/path/"
+        path = "/fake/path/fake-file"
 
-        expected_artifact_payload = {
-            "artifacts": [f"{path}{temp_file.split('/')[-1]}"]
-        }
+        expected_artifact_payload = {"artifacts": [path]}
 
         result = create_artifact_delete_payload_from_filepath(
-            filepath=temp_file,
-            path=path,
-        )
-        assert result == expected_artifact_payload
-
-    def test_create_artifact_add_payload_from_filepath_without_path(
-        self,
-        temp_file: str,
-    ) -> None:
-        """
-        Test that the artifact payload is created correctly given the
-        filepath of the artifact
-        """
-
-        path = None
-
-        expected_artifact_payload = {
-            "artifacts": [f"{temp_file.split('/')[-1]}"]
-        }
-
-        result = create_artifact_delete_payload_from_filepath(
-            filepath=temp_file,
             path=path,
         )
         assert result == expected_artifact_payload


### PR DESCRIPTION

# Description

This PR came out from KubeCon 2025 in London where we use it during the demos.
I just added some tests and it look good now.

## `rstuf artifact repository add`

- Fix when users want to use a local trusted file, importing it correctly
- Allow uses to use Root metadata from metadata url as import

## `rstuf artifact download`

- Fix users to download using Trust-on-First-usage (TOFU), by downloading the 1.root.json


## `rstuf artifact delete` 

- Fix the usage by not requiring the file to exists locally as it doesn't require any information such as hash or size for delete, only the path

# Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct