### PR TITLE
feat: task info all data `rstuf task info --all|-a <task id>`

### DIFF
--- a/repository_service_tuf/cli/task/info.py
+++ b/repository_service_tuf/cli/task/info.py
@@ -3,10 +3,11 @@
 from typing import Any, Dict
 
 from click import Context
+from rich import print_json
 
 from repository_service_tuf.cli import HEADERS_EXAMPLE, _set_settings, click
 from repository_service_tuf.cli.task import task
-from repository_service_tuf.helpers.api_client import task_status
+from repository_service_tuf.helpers.api_client import get_task, task_status
 
 
 @task.command()
@@ -14,6 +15,14 @@ from repository_service_tuf.helpers.api_client import task_status
     "task_id",
     type=str,
     required=True,
+)
+@click.option(
+    "--all",
+    "-a",
+    help="Show all task details.",
+    is_flag=True,
+    required=False,
+    default=False,
 )
 @click.option(
     "--api-server",
@@ -28,7 +37,7 @@ from repository_service_tuf.helpers.api_client import task_status
 )
 @click.pass_context
 def info(
-    context: Context, task_id: str, api_server: str, headers: str
+    context: Context, task_id: str, api_server: str, headers: str, all: bool
 ) -> Dict[str, Any]:
     """
     Retrieve task state.
@@ -46,6 +55,11 @@ def info(
             "Requires '--api-server' or configuring the `.rstuf.yml` file. "
             "Example: --api-server https://api.rstuf.example.com"
         )
+
+    if all:
+        data, _ = get_task(task_id=task_id, settings=settings)
+
+        print_json(data=data)
 
     status = task_status(
         task_id=task_id, settings=settings, title="Task status:"

--- a/tests/unit/cli/task/test_info.py
+++ b/tests/unit/cli/task/test_info.py
@@ -19,11 +19,14 @@ class TestTaskInfoInteraction:
         input_steps = [
             "--api-server",
             "http://127.0.0.1",
+            "--all",
             task_id,
         ]
 
         info.task_status = pretend.call_recorder(lambda *a, **kw: "123")
-
+        info.get_task = pretend.call_recorder(
+            lambda *a, **kw: ({"task_id": task_id}, 200)
+        )
         result = client.invoke(info.info, input_steps, obj=test_context)
 
         assert info.task_status.calls == [
@@ -31,6 +34,12 @@ class TestTaskInfoInteraction:
                 task_id=task_id,
                 settings=test_context["settings"],
                 title="Task status:",
+            )
+        ]
+        assert info.get_task.calls == [
+            pretend.call(
+                task_id=task_id,
+                settings=test_context["settings"],
             )
         ]
 


### PR DESCRIPTION
# Description

This feature was also added during KubeCon 2025 in London while demonstrate RSTUF.

Depending of the task you want to see all details.

This commit shows the Task data for more detailed view when using `--all|-a`



# Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct