### PR TITLE
fix: `rstuf admin metadata sign|stop-sign` preview

### DIFF
--- a/repository_service_tuf/cli/admin/helpers.py
+++ b/repository_service_tuf/cli/admin/helpers.py
@@ -1088,17 +1088,17 @@ def _print_root(root: Root):
     console.print(root_table)
 
 
-def _print_targets(targets: Targets):
+def _print_targets(targets: Metadata[Targets]):
     """Pretty print targets metadata."""
 
     targets_table = Table("Version", "Artifacts")
     artifact_table = Table("Path", "Info", show_lines=True)
 
-    for path, info in targets.targets.items():
+    for path, info in targets.signed.targets.items():
         artifact_table.add_row(
             path, JSON.from_data(info.to_dict()), style="bold"
         )
-    targets_table.add_row(str(targets.version), artifact_table)
+    targets_table.add_row(str(targets.signed.version), artifact_table)
     console.print(targets_table)
 
 

--- a/repository_service_tuf/cli/admin/metadata/sign.py
+++ b/repository_service_tuf/cli/admin/metadata/sign.py
@@ -115,7 +115,7 @@ def sign(
 
     console.print("\nSelect a role to sign:")
     role = _select_role(pending_roles)
-    role_md = Metadata.from_dict(pending_roles[role])
+    role_md: Metadata = Metadata.from_dict(pending_roles[role])
 
     if role_md.signed.type == Root.type:
         version = role_md.signed.version
@@ -157,7 +157,7 @@ def sign(
         targets = Metadata[Targets].from_dict(pending_roles["trusted_targets"])
         # sign Targets metadata
         console.print(Markdown("## metadata to be signed"))
-        _print_targets(targets.signed)
+        _print_targets(role_md)
         keys = []
         if targets.signed.delegations is None:
             raise click.ClickException("No custom delegations")

--- a/repository_service_tuf/cli/admin/metadata/stop_sign.py
+++ b/repository_service_tuf/cli/admin/metadata/stop_sign.py
@@ -48,11 +48,13 @@ def stop_sign(context: click.Context) -> None:
     while True:
         console.print("\nSelect which metadata signing process to stop:")
         role = _select_role(pending_roles)
-        md: Metadata = Metadata.from_dict(copy.deepcopy(pending_roles[role]))
-        if md.signed.type == Root.type:
-            _print_root(md.signed)
-        elif md.signed.type == Targets.type:
-            _print_targets(md.signed)
+        metadata: Metadata = Metadata.from_dict(
+            copy.deepcopy(pending_roles[role])
+        )
+        if metadata.signed.type == Root.type:
+            _print_root(metadata.signed)
+        elif metadata.signed.type == Targets.type:
+            _print_targets(metadata)
 
         confirmation = prompt.Confirm.ask(
             f"\nDo you still want to stop signing process for {role}?"


### PR DESCRIPTION
# Description

The preview wasn't work properly for signing or stop signing when the Metadata was a Targets type.

the _print_targets() expected the full metadata and not the signed portion.

Fixes PR #696

# Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct