### PR TITLE
fix: `admin` command fails while using headers

### DIFF
--- a/repository_service_tuf/cli/admin/helpers.py
+++ b/repository_service_tuf/cli/admin/helpers.py
@@ -1044,7 +1044,10 @@ def _parse_pending_data(pending_roles_resp: Dict[str, Any]) -> Dict[str, Any]:
 def _get_pending_roles(settings: Any) -> Dict[str, Dict[str, Any]]:
     """Get dictionary of pending roles for signing."""
     response = request_server(
-        settings.SERVER, URL.METADATA_SIGN.value, Methods.GET
+        settings.SERVER,
+        URL.METADATA_SIGN.value,
+        Methods.GET,
+        headers=settings.HEADERS,
     )
     if response.status_code != 200:
         raise click.ClickException(

--- a/tests/unit/cli/admin/test_helpers.py
+++ b/tests/unit/cli/admin/test_helpers.py
@@ -553,7 +553,7 @@ class TestHelpers:
         assert "No metadata available for signing" in str(e)
 
     def test__get_pending_roles_request(self, monkeypatch):
-        fake_settings = pretend.stub(SERVER=None)
+        fake_settings = pretend.stub(SERVER=None, HEADERS=None)
         fake_json = pretend.stub()
         response = pretend.stub(
             status_code=200, json=pretend.call_recorder(lambda: fake_json)
@@ -575,6 +575,7 @@ class TestHelpers:
                 fake_settings.SERVER,
                 URL.METADATA_SIGN.value,
                 Methods.GET,
+                headers=None,
             )
         ]
         assert response.json.calls == [pretend.call()]
@@ -583,6 +584,7 @@ class TestHelpers:
     def test__get_pending_roles_request_bad_status_code(self, monkeypatch):
         fake_settings = pretend.stub(
             SERVER="http://localhost:80",
+            HEADERS=None,
         )
         response = pretend.stub(status_code=400, text="")
         fake_request_server = pretend.call_recorder(lambda *a, **kw: response)
@@ -596,6 +598,7 @@ class TestHelpers:
                 fake_settings.SERVER,
                 URL.METADATA_SIGN.value,
                 Methods.GET,
+                headers=None,
             )
         ]
 


### PR DESCRIPTION
# Description

headers is not passed to `request_server` which cause error if headers is required to access RSTUF.

# Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct