### PR TITLE
Pin GitHub Actions versions cache to specific commit SHA 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Restore mypy cache
       id: cache-mypy-restore
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684
       with:
         path: |
           .mypy_cache
@@ -43,7 +43,7 @@ jobs:
 
     - name: Save mypy cache
       id: cache-mypy-save
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684
       with:
         path: |
           .mypy_cache


### PR DESCRIPTION

<!--- Thanks for taking the time to fill out this pull request! -->
<!--- Please fill in the fields below to submit a pull request. 
The more information provided, the better. -->


# Description
<!--- What is the PR about? -->
Pinning the GitHub Actions version to a specific commit to follow the repository standard. We are using the [current latest commit from GitHub Actions cache repository](https://github.com/actions/cache/commit/5a3ec84eff668545956fd18022155c47e93e2684) for the pin.

<!--- Please reference the issue(s) this PR fixes. -->
Fixes #652


# Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct