### PR TITLE
docs: add `make help`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,28 @@
-.PHONY: all docs tests coverage reformat requirements
+.PHONY: all docs tests coverage reformat requirements precommit run-dev clone-umbrella ft-das ft-signed stop clean help
 
-reformat:
+all: help
+
+reformat:  ## Reformat code with black and isort
 	black -l 79 .
 	isort -l79 --profile black .
 
-tests:
+tests:  ## Run all tests
 	tox -r
 
-requirements:
-	pipenv lock
-
-precommit:
+precommit:  ## Install and run pre-commit hooks
 	pre-commit install
 	pre-commit run --all-files --show-diff-on-failure
 
-coverage:
+coverage:  ## Run tests with coverage
 	coverage report
 	coverage html -i
 
-docs:
+docs:  ## Build documentation
 	tox -e docs
 
 run-dev: export API_VERSION = dev
 run-dev: export WORKER_VERSION = dev
-run-dev:
+run-dev:  ## Run the development environment
 	docker pull ghcr.io/repository-service-tuf/repository-service-tuf-api:dev
 	docker pull ghcr.io/repository-service-tuf/repository-service-tuf-worker:dev
 	docker compose -f docker-compose.yml up --remove-orphans
@@ -51,11 +50,17 @@ ifeq ($(GITHUB_ACTION),)
 endif
 	docker compose run --env UMBRELLA_PATH=rstuf-umbrella --rm rstuf-ft-runner bash rstuf-umbrella/tests/functional/scripts/run-ft-signed.sh $(CLI_VERSION) $(PYTEST_GROUP) $(SLOW)
 
-stop:
+stop:  ## Stop the development environment
 	docker compose down -v
 
-clean:
+clean:  ## Clean up the environment
 	$(MAKE) stop
 	docker compose rm --force
 	rm -rf ./data
 	rm -rf ./data_test
+
+help:  ## Show this help message
+	@echo "Makefile commands:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+	awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'	
+	@echo


### PR DESCRIPTION
help developers/contributors see the supported help commands

```shell
❯ make
Makefile commands:
reformat                       Reformat code with black and isort
tests                          Run all tests
precommit                      Install and run pre-commit hooks
coverage                       Run tests with coverage
docs                           Build documentation
run-dev                        Run the development environment
stop                           Stop the development environment
clean                          Clean up the environment
help                           Show this help message
```