### PR TITLE
Updated docker images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ volumes:
 
 services:
   postgres:
-    image: postgres:15.1
+    image: postgres:17.5-alpine3.21
     ports:
       - "5433:5432"
     environment:
@@ -42,7 +42,7 @@ services:
       - "8080:8080"
 
   redis:
-    image: redis:4.0
+    image: redis:8.0.0-alpine3.21
     volumes:
       - repository-service-tuf-redis-data:/data
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
     stdin_open: true
 
   rstuf-ft-runner:
-    image: python:3.12-slim
+    image: python:3.13-slim
     command: python -V
     working_dir: /rstuf-runner
     volumes:


### PR DESCRIPTION
Upgrades the docker containers from:
    
* Postress 15.1 to 17.5
Both have the same vulnerability scores and none of the other images have a lower vulnerability score.

* python 3.12 to 3.13
3.13 image has no identified vulnerabilities until now
    
* redis 4.0 to 8.0
The 4.0 image had vulnerabilities while the 8.0 doesn't have any vulnerabilities until now.

# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).

- [x] I agree to follow this project's Code of Conduct