### PR TITLE
Fix incorrectly produced error message for new delegation

### DIFF
--- a/repository_service_tuf/cli/admin/delegations/new.py
+++ b/repository_service_tuf/cli/admin/delegations/new.py
@@ -118,7 +118,7 @@ def new(
             settings,
             URL.DELEGATIONS.value,
             {"delegations": delegations.to_dict()},
-            "New Metadata accepted.",
+            "Metadata delegation add accepted.",
             "New Metadata finished.",
         )
         task_status(task_id, settings, "New Metadata status:")


### PR DESCRIPTION
# Description
Changed the expected message string which fixes the issue. Previous string was having mismatch inside the `send_payload` function here, which resulted in producing the error message instead of success here.

https://github.com/repository-service-tuf/repository-service-tuf-cli/blob/765aadea3f9dd100ffe5bfb6eddc4a4f53542bf4/repository_service_tuf/helpers/api_client.py#L230-L234

Fixes #898 

@kairoaraujo 