### PR TITLE
[Feature Support]: Update CLI to enable hash-bin delegations under custom delegations

### DIFF
--- a/repository_service_tuf/cli/admin/helpers.py
+++ b/repository_service_tuf/cli/admin/helpers.py
@@ -961,7 +961,7 @@ def _configure_delegations() -> Delegations:
                 if num_nested_bins:
                     signing_method = _select(["Online Key (use the existing)"])
                 else:
-                    signing_method = _select(["Online Key (use the existing)"])
+                    signing_method = _select(["Online Key (use the existing)", "Add Keys"])
                 if signing_method == "Add Keys":
                     delegated_role.threshold = _threshold_prompt(
                         delegated_role.name


### PR DESCRIPTION
## Description
Introduced support for nested hash-bin delegations under custom delegations in the RSTUF CLI. The changes add interactive prompts to configure nested bins, update the delegation metadata to store bin information, and clarify the signing method restrictions for nested bins. Additionally, the delegation metadata display now includes the number of nested bins for each delegation.

### Nested hash-bin delegation support

* Added `_prompt_nested_bins` function to prompt users for the creation and number of nested hash-bin delegations under a custom delegation. The number of bins is restricted to powers of two between 2 and 4096. 
* Updated `_configure_delegations` to use `_prompt_nested_bins`, pass the bin count to `_expiry_prompt`, and store the bin count in the delegation's metadata (`x-rstuf-num-bins`). 

### Signing method restrictions

* Updated the signing method selection and user-facing documentation to clarify that only global online key (existing) is supported for both custom roles and their nested bins when hash-bin delegations are used. Offline keys are not supported for nested bins as of now.

### Delegation metadata and display

* Modified the delegation metadata table to include a "Nested Bins" column, showing the number of bins for each delegation if present.

### Expiry prompt improvements

* Enhanced `_expiry_prompt` to accept an optional `num_bins` parameter, updating the prompt messaging when nested bins are being configured. 

Related Issue: https://github.com/repository-service-tuf/repository-service-tuf/issues/876

@kairoaraujo 