### PR TITLE
fix: use public key filename instead of keyid for online key URI

### DIFF
--- a/repository_service_tuf/cli/admin/helpers.py
+++ b/repository_service_tuf/cli/admin/helpers.py
@@ -354,8 +354,8 @@ def _prompt_public_key() -> str:
     return _prompt_key(message, file_filter)
 
 
-def _load_key_from_file_prompt() -> SSlibKey:
-    """Prompt for path to public key, return Key."""
+def _load_key_from_file_prompt() -> Tuple[SSlibKey, str]:
+    """Prompt for path to public key, return Key and path."""
 
     path = _prompt_public_key()
 
@@ -365,7 +365,7 @@ def _load_key_from_file_prompt() -> SSlibKey:
     crypto = load_pem_public_key(public_pem)
     key = SSlibKey.from_crypto(crypto)
 
-    return key
+    return key, path
 
 
 def _load_key_from_hsm_prompt() -> SSlibKey:
@@ -447,7 +447,7 @@ def _load_key_prompt(
         key: SSlibKey | SigstoreKey
         match signer_type:
             case ROOT_SIGNERS.KEY_PEM:
-                key = _load_key_from_file_prompt()
+                key, _ = _load_key_from_file_prompt()
             case ROOT_SIGNERS.SIGSTORE:
                 key = _load_key_from_sigstore_prompt()
             case ROOT_SIGNERS.HSM:
@@ -473,8 +473,13 @@ def _load_online_key_prompt(
     try:
         match signer_type:
             case ONLINE_SIGNERS.KEY_PEM:
-                key = _load_key_from_file_prompt()
-                uri = f"fn:{key.keyid}"
+                key, path = _load_key_from_file_prompt()
+                key_name = os.path.splitext(os.path.basename(path))[0]
+                if not key_name:
+                    raise ValueError(
+                        f"Cannot derive key name from path: {path}"
+                    )
+                uri = f"fn:{key_name}"
 
             case ONLINE_SIGNERS.AWSKMS:
                 uri, key = AWSSigner.import_(Prompt.ask("AWS KMS KeyID"))

--- a/tests/unit/cli/admin/test_helpers.py
+++ b/tests/unit/cli/admin/test_helpers.py
@@ -86,9 +86,10 @@ class TestHelpers:
         # success
         inputs = [f"{_PEMS / 'JH.pub'}"]
         with patch(_PROMPT_TOOLKIT, side_effect=inputs):
-            key = helpers._load_key_from_file_prompt()
+            key, path = helpers._load_key_from_file_prompt()
 
         assert isinstance(key, SSlibKey)
+        assert path == f"{_PEMS / 'JH.pub'}"
 
         # fail with wrong file
         inputs = [f"{_PEMS / 'JH.ed25519'}"]
@@ -146,8 +147,13 @@ class TestHelpers:
 
         # return key
         fake_key = pretend.stub(keyid="abc")
+        key_rv = (
+            (fake_key, "/path/to/key.pub")
+            if key_load == "_load_key_from_file_prompt"
+            else fake_key
+        )
         with (
-            patch(f"{_HELPERS}.{key_load}", return_value=fake_key),
+            patch(f"{_HELPERS}.{key_load}", return_value=key_rv),
             patch(
                 f"{_HELPERS}._select",
                 side_effect=[signer_type],
@@ -160,7 +166,8 @@ class TestHelpers:
         # return None - key in use
         fake_key = pretend.stub(keyid="123")
         with patch(
-            f"{_HELPERS}._load_key_from_file_prompt", return_value=fake_key
+            f"{_HELPERS}._load_key_from_file_prompt",
+            return_value=(fake_key, "/path/to/key.pub"),
         ):
             key = helpers._load_key_prompt(fake_root)
 
@@ -182,7 +189,7 @@ class TestHelpers:
                 helpers.ONLINE_SIGNERS.KEY_PEM,  # signer_type
                 [],  # No prompt input needed for KEY_PEM
                 f"{_HELPERS}._load_key_from_file_prompt",  # Mocked signer
-                "fn:abc",  # Expected URI
+                "fn:online",  # Expected URI — stem of the .pub filename
                 pretend.stub(keyid="abc"),  # Expected key object
             ),
             # Test for AWS KMS
@@ -231,7 +238,7 @@ class TestHelpers:
 
         # Mocking the necessary methods based on the signer type
         if signer_type == helpers.ONLINE_SIGNERS.KEY_PEM:
-            return_value = expected_key
+            return_value = (expected_key, "/path/to/online.pub")
         else:
             return_value = (expected_uri, expected_key)
         with patch(signer_mock, return_value=return_value):
@@ -256,7 +263,8 @@ class TestHelpers:
         fake_key = pretend.stub(keyid="abc")
 
         with patch(
-            f"{_HELPERS}._load_key_from_file_prompt", return_value=fake_key
+            f"{_HELPERS}._load_key_from_file_prompt",
+            return_value=(fake_key, "/path/to/online.pub"),
         ):
             uri, key = helpers._load_online_key_prompt(
                 fake_root, helpers.ONLINE_SIGNERS.KEY_PEM
@@ -264,6 +272,21 @@ class TestHelpers:
 
         assert key is None
         assert uri is None
+
+    def test_load_online_key_prompt_key_pem_empty_filename(self):
+        fake_root = pretend.stub(keys={})
+        fake_key = pretend.stub(keyid="abc")
+
+        with patch(
+            f"{_HELPERS}._load_key_from_file_prompt",
+            return_value=(fake_key, "/path/to/"),
+        ):
+            uri, key = helpers._load_online_key_prompt(
+                fake_root, helpers.ONLINE_SIGNERS.KEY_PEM
+            )
+
+        assert uri is None
+        assert key is None
 
     @pytest.mark.parametrize(
         "signer_type, exception",


### PR DESCRIPTION
## Problem

During the TUF ceremony, `_load_online_key_prompt()` was deriving the online key URI as `fn:<keyid>`. The worker's `FileNameSigner` loads the private key by **filename** using the `fn:` scheme, not by keyid.

This meant the URI written into the root metadata pointed to a file that did not exist, causing signing to fail silently on first use.

fixes #642 also ref [#431](https://github.com/repository-service-tuf/repository-service-tuf-worker/issues/431)
## Changes

**`helpers.py`**

* `_load_key_from_file_prompt()` return type changed from `SSlibKey` to `Tuple[SSlibKey, str]` — now returns both the key and the file path
* Root key caller updated to unpack with `key, _ = ...`
* Online key caller updated to unpack with `key, path = ...`, derives
  `key_name = os.path.splitext(os.path.basename(path))[0]`, and writes
  `uri = f"fn:{key_name}"`
* Guard added: raises `ValueError` if the filename stem is empty

**`test_helpers.py`**

* `test_load_key_from_file_prompt` updated to unpack tuple and assert path returned
* `test_load_online_key_prompt_success_cases` KEY_PEM case updated: mock returns `(key, "/path/to/online.pub")`, expected URI is `"fn:online"`
* `test_load_online_key_prompt_key_already_in_use` mock updated to return tuple
* New: `test_load_online_key_prompt_key_pem_empty_filename` — verifies empty filename stem raises and returns `(None, None)`

**note** 
Worker pr  [#845 ](https://github.com/repository-service-tuf/repository-service-tuf-worker/pull/845) fixes the dict mutation `(.pop("keyid")` modifying shared state) and adds a clear error message when `x-rstuf-online-key-uri `is missing
CLI pr [#918](https://github.com/repository-service-tuf/repository-service-tuf-cli/pull/918) — fixes the ceremony writing the key identifier instead of `fn:<filename> `into `x-rstuf-online-key-uri`, so the worker can actually find the key file at signing time