### PR TITLE
fix: assert online roles share the same single keyid

### DIFF
--- a/repository_service_tuf/cli/admin/helpers.py
+++ b/repository_service_tuf/cli/admin/helpers.py
@@ -1018,19 +1018,22 @@ def _get_root_keys(root: Root) -> Dict[str, Key]:
 def _get_online_key(root: Root) -> Optional[Key]:
     keyid_sets = {
         role_name: frozenset(root.roles[role_name].keyids)
-        for role_name in ONLINE_ROLE_NAMES
+        for role_name in sorted(ONLINE_ROLE_NAMES)
     }
     unique = set(keyid_sets.values())
     if len(unique) > 1:
         raise ValueError(
             "Online roles have mismatched keyids: "
-            + ", ".join(f"{r}={list(k)}" for r, k in keyid_sets.items())
+            + ", ".join(
+                f"{r}={sorted(k)}" for r, k in keyid_sets.items()
+            )
         )
 
     keyids = keyid_sets[Timestamp.type]
     if len(keyids) > 1:
         raise ValueError(
-            f"Online roles must have at most one keyid, got {list(keyids)}"
+            "Online roles must have at most one keyid, got "
+            f"{sorted(keyids)}"
         )
 
     if not keyids:

--- a/repository_service_tuf/cli/admin/helpers.py
+++ b/repository_service_tuf/cli/admin/helpers.py
@@ -1016,12 +1016,27 @@ def _get_root_keys(root: Root) -> Dict[str, Key]:
 
 
 def _get_online_key(root: Root) -> Optional[Key]:
-    # TODO: assert all online roles have the same and only one keyid, or none
-    key = None
-    if root.roles[Timestamp.type].keyids:
-        key = root.get_key(root.roles[Timestamp.type].keyids[0])
+    keyid_sets = {
+        role_name: frozenset(root.roles[role_name].keyids)
+        for role_name in ONLINE_ROLE_NAMES
+    }
+    unique = set(keyid_sets.values())
+    if len(unique) > 1:
+        raise ValueError(
+            "Online roles have mismatched keyids: "
+            + ", ".join(f"{r}={list(k)}" for r, k in keyid_sets.items())
+        )
 
-    return key
+    keyids = keyid_sets[Timestamp.type]
+    if len(keyids) > 1:
+        raise ValueError(
+            f"Online roles must have at most one keyid, got {list(keyids)}"
+        )
+
+    if not keyids:
+        return None
+
+    return root.get_key(next(iter(keyids)))
 
 
 def _parse_pending_data(pending_roles_resp: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/unit/cli/admin/test_helpers.py
+++ b/tests/unit/cli/admin/test_helpers.py
@@ -536,9 +536,25 @@ class TestHelpers:
         root = Root()
         assert not helpers._get_online_key(root)
 
-        # NOTE: cli doesn't validate that all online roles have the same key
-        root.add_key(ed25519_key, "timestamp")
+        for role_name in helpers.ONLINE_ROLE_NAMES:
+            root.add_key(ed25519_key, role_name)
         assert helpers._get_online_key(root) == ed25519_key
+
+    def test_get_online_key_mismatched_keyids(self, ed25519_key):
+        root = Root()
+        root.add_key(ed25519_key, "timestamp")
+        with pytest.raises(ValueError, match="mismatched keyids"):
+            helpers._get_online_key(root)
+
+    def test_get_online_key_multiple_keyids(self, ed25519_key):
+        root = Root()
+        ed25519_key2 = copy.deepcopy(ed25519_key)
+        ed25519_key2.keyid = "fake_keyid2"
+        for role_name in helpers.ONLINE_ROLE_NAMES:
+            root.add_key(ed25519_key, role_name)
+            root.add_key(ed25519_key2, role_name)
+        with pytest.raises(ValueError, match="at most one keyid"):
+            helpers._get_online_key(root)
 
     def test__parse_pending_data(self):
         fake_md = {"root": Metadata(Root()).to_dict()}


### PR DESCRIPTION
# Description                                                                                                                                 
                                                                                                                                              
There was a TODO in `_get_online_key` noting that the function only grabbed the timestamp role's key and hoped the others matched, but never actually checked. This fixes that by validating all online roles share the same single keyid (or none), and raises a clear error if they don't.                                                                               
                                                                                                                                              
Also updated the existing test and added a couple new ones for the mismatched and multiple keyid scenarios.                                                                                                      
                                                                                                                                              
# Types of changes                                                                                                                         
- [x] Bug fix (non-breaking change which fixes an issue)

# Additional requirements
- [x] Tests have been added for the bug fix or new feature                                                                                    
- [ ] Docs have been added for the bug fix or new feature                                                                                     
                                                                                                                                              
# Code of Conduct                                                                                                                             
- [x] I agree to follow this project's Code of Conduct 