### PR TITLE
fix: resolve test failures and add Windows HSM paths

### DIFF
--- a/repository_service_tuf/cli/admin/helpers.py
+++ b/repository_service_tuf/cli/admin/helpers.py
@@ -105,6 +105,10 @@ LIBYKCS11_LOCATIONS = {
         "/opt/homebrew/lib/libykcs11.dylib",
         "/usr/local/lib/libykcs11.dylib",
     ],
+    "Windows": [
+        "C:\\Program Files\\Yubico\\Yubico PIV Tool\\bin\\libykcs11.dll",
+        "C:\\Program Files (x86)\\Yubico\\Yubico PIV Tool\\bin\\libykcs11.dll",
+    ],
 }
 
 # SecureSystemsLib doesn't support SigstoreKey by default.
@@ -452,6 +456,8 @@ def _load_key_prompt(
                 key = _load_key_from_sigstore_prompt()
             case ROOT_SIGNERS.HSM:
                 key = _load_key_from_hsm_prompt()
+            case _:
+                return None
 
     except (OSError, ValueError) as e:
         console.print(f"Cannot load key: {e}")

--- a/tests/unit/cli/admin/test_helpers.py
+++ b/tests/unit/cli/admin/test_helpers.py
@@ -159,10 +159,14 @@ class TestHelpers:
 
         # return None - key in use
         fake_key = pretend.stub(keyid="123")
-        with patch(
-            f"{_HELPERS}._load_key_from_file_prompt", return_value=fake_key
+        with (
+            patch(f"{_HELPERS}.{key_load}", return_value=fake_key),
+            patch(
+                f"{_HELPERS}._select",
+                side_effect=[signer_type],
+            ),
         ):
-            key = helpers._load_key_prompt(fake_root)
+            key = helpers._load_key_prompt(fake_root.keys, duplicate=False)
 
         assert key is None
 
@@ -754,6 +758,10 @@ class TestHelpers:
                 self.name = fake_dir_name
 
         monkeypatch.setattr(f"{_HELPERS}.TemporaryDirectory", FakeTempDir)
+        monkeypatch.setattr(
+            f"{_HELPERS}.requests.get",
+            pretend.raiser(OSError("Connection refused")),
+        )
         fake_url = "http://localhost:8080"
 
         with pytest.raises(click.ClickException) as e:
@@ -762,7 +770,8 @@ class TestHelpers:
         # The error message can be either "Cannot fetch initial root" or
         # "Problem fetching latest root" depending on the exception path
         error_msg = str(e.value)
-        assert "fetch" in error_msg.lower() and "root" in error_msg.lower()
+        assert "fetch" in error_msg.lower()
+        assert "root" in error_msg.lower()
 
     def test_load_key_from_sigstore_prompt(self):
         fake_issuer = "Google"


### PR DESCRIPTION
## Summary

Fixes test failures in `tests/unit/cli/admin/test_helpers.py` and adds
Windows paths for HSM support. Related to #817.

## Changes

### `repository_service_tuf/cli/admin/helpers.py`

- **Added default `case _: return None` in `_load_key_prompt`.**
  The `match` statement had no default branch, so if `signer_type` did
  not match any case the local variable `key` was referenced before
  assignment, raising `UnboundLocalError`. Returning `None` aligns with
  the existing error paths in the same function.

- **Added a `"Windows"` entry to `LIBYKCS11_LOCATIONS`** with the default
  Yubico PIV Tool install paths (`Program Files` and `Program Files (x86)`).
  Previously `platform.system()` returning `"Windows"` produced an empty
  list, making `_load_signer_from_hsm_prompt` raise `ClickException`
  immediately on Windows. Paths are based on Yubico's documented install
  locations; I was not able to verify end-to-end with physical hardware
  on Windows, so feedback from anyone who can is welcome.

### `tests/unit/cli/admin/test_helpers.py`

- **`test_load_key_prompt`** — the "key in use" branch was passing
  `fake_root` (a stub) where `_load_key_prompt` expects a `keys` dict,
  hardcoding `_load_key_from_file_prompt` instead of using the
  parametrized `key_load`, and not mocking `_select`. Updated to:
  - use `patch(f"{_HELPERS}.{key_load}", ...)`
  - mock `_select` with `side_effect=[signer_type]`
  - call `helpers._load_key_prompt(fake_root.keys, duplicate=False)`

- **`test__get_latest_md_root_OS_error`** — the test was not mocking
  `requests.get`, so it made a real TCP connection to
  `http://localhost:8080` and hung until the 300s timeout. Added a
  `monkeypatch` on `requests.get` that raises `OSError("Connection refused")`,
  which is what the test name implies it was always meant to exercise.
  Runtime drops from ~300s to ~0.08s.

- Split a combined `and` assertion into two separate `assert` statements
  for clearer failure output.

## Testing

- `pytest tests/` — **174 passed**, 0 failures, 0 skips
- `pre-commit`: flake8, black, isort, bandit, mypy all pass
  (the pre-existing `tox-requirements` hook failure is unrelated and
  reproduces on `main`)
