### PR TITLE
fix: handle unencrypted keys correctly in ceremony (RSTUF-CR-25-108)

### DIFF
--- a/repository_service_tuf/cli/admin/helpers.py
+++ b/repository_service_tuf/cli/admin/helpers.py
@@ -310,17 +310,22 @@ def _load_signer_from_file_prompt(public_key: SSlibKey) -> CryptoSigner:
         with open(path, "rb") as f:
             private_pem = f.read()
 
-        # Because of click.prompt we are required to use click.style()
-        name_str = click.style(name_value, fg="green")
-        password_str = click.style("password", fg="yellow")
-        password = click.prompt(
-            f"\nPlease enter {password_str} to encrypted private key '{name_str}'",  # noqa
-            hide_input=True,
-        )
+        if b"ENCRYPTED" in private_pem:
+            name_str = click.style(name_value, fg="green")
+            password_str = click.style("password", fg="yellow")
+
+            password = click.prompt(
+                f"\nPlease enter {password_str} to encrypted private key '{name_str}'",
+                hide_input=True,
+            )
+            password_bytes = password.encode()
+        else:
+            password_bytes = None
+
         try:
-            private_key = load_pem_private_key(private_pem, password.encode())
+            private_key = load_pem_private_key(private_pem, password_bytes)
             break
-        except TypeError as e:
+        except (ValueError, TypeError) as e:
             console.print(f"Cannot load key: {e}")
 
     return CryptoSigner(private_key, public_key)


### PR DESCRIPTION
This PR fixes an issue where the CLI prompts for a password even when the provided private key is not encrypted.

The logic now checks whether the key is actually encrypted before requesting a password:
- If the key is encrypted, the password prompt is shown as expected.
- If the key is not encrypted, it is loaded directly without prompting.

Additionally, error handling has been improved to ensure the CLI does not crash when invalid input or incorrect passwords are provided. Instead, a clear error message is shown.

This issue originates from the RSTUF security audit tracking issue:
https://github.com/repository-service-tuf/repository-service-tuf/issues/845

The fix is implemented in the CLI component where the issue occurs.