### PR TITLE
feat: support unrecognized fields in root metadata (#608)

### DIFF
--- a/repository_service_tuf/cli/admin/ceremony.py
+++ b/repository_service_tuf/cli/admin/ceremony.py
@@ -34,6 +34,7 @@ from repository_service_tuf.cli.admin.helpers import (
     _print_root,
     _settings_prompt,
     _threshold_prompt,
+    _unrecognized_fields_prompt,
 )
 from repository_service_tuf.helpers.api_client import (
     URL,
@@ -131,6 +132,11 @@ def ceremony(
     # Configure Online Key
     console.print(Markdown("## Online Key"))
     _configure_online_key_prompt(root)
+
+    ###########################################################################
+    # Configure Unrecognized Fields
+    console.print(Markdown("## Unrecognized Fields"))
+    _unrecognized_fields_prompt(root)
 
     ###########################################################################
     # Review Metadata

--- a/repository_service_tuf/cli/admin/helpers.py
+++ b/repository_service_tuf/cli/admin/helpers.py
@@ -692,6 +692,43 @@ def _configure_online_key_prompt(root: Root) -> None:
     console.print(f"Expected private key file name is: '{new_key.keyid}'")
 
 
+def _unrecognized_fields_prompt(root: Root) -> None:
+    """Prompt dialog to set or update unrecognized fields."""
+    import re
+    if root.unrecognized_fields:
+        console.print("\nCurrent unrecognized fields:")
+        for k, v in root.unrecognized_fields.items():
+            if k.startswith("x-"):
+                console.print(f"  {k}: {v}")
+        if not Confirm.ask("Do you want to change unrecognized fields?", default=False):
+            return
+        if Confirm.ask("Do you want to clear existing unrecognized fields?", default=False):
+            # Only remove fields matching the format to avoid removing internal ones if any
+            to_remove = [k for k in root.unrecognized_fields if k.startswith("x-") and "-" in k[2:]]
+            for k in to_remove:
+                del root.unrecognized_fields[k]
+
+    if not Confirm.ask("Do you want to add unrecognized fields?", default=False):
+        return
+
+    while True:
+        name = Prompt.ask("Field name (format: x-<vendor>-<name>)")
+        if not name:
+            break
+
+        if not re.match(r"^x-[a-zA-Z0-9_]+-[a-zA-Z0-9_-]+$", name):
+            console.print("Invalid format. Every extra field must follow format: x-<vendor>-<name>", style="bold red")
+            continue
+
+        value = Prompt.ask(f"Field value for '{name}'")
+        if getattr(root, "unrecognized_fields", None) is None:
+            root.unrecognized_fields = {}
+        root.unrecognized_fields[name] = value
+
+        if not Confirm.ask("Do you want to add another unrecognized field?", default=False):
+            break
+
+
 def _add_signature_prompt(metadata: Metadata, key: Key) -> Signature:
     """Prompt for signing key and add signature to metadata until success."""
     while True:

--- a/repository_service_tuf/cli/admin/metadata/update.py
+++ b/repository_service_tuf/cli/admin/metadata/update.py
@@ -30,6 +30,7 @@ from repository_service_tuf.cli.admin.helpers import (
     _get_latest_md,
     _print_root,
     _threshold_prompt,
+    _unrecognized_fields_prompt,
 )
 from repository_service_tuf.cli.admin.metadata import metadata
 from repository_service_tuf.helpers.api_client import (
@@ -155,6 +156,11 @@ def update(
     # Configure Online Key
     console.print(Markdown("## Online Key"))
     _configure_online_key_prompt(root)
+
+    ###########################################################################
+    # Configure Unrecognized Fields
+    console.print(Markdown("## Unrecognized Fields"))
+    _unrecognized_fields_prompt(root)
 
     ###########################################################################
     # Bump version

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,6 +82,7 @@ def ceremony_inputs() -> Tuple[List[str], List[str], List[str], List[str]]:
     ]
     input_step3 = [  # Configure Online Key
         "Online Key",  # Please enter a key name
+        "",  # Do you want to add unrecognized fields? (N)
     ]
     input_step4: List[str] = []  # Sign Metadata
 
@@ -174,6 +175,7 @@ def update_inputs():
         "JoeCocker's Key",  # Please enter a key name
         "y",  # Do you want to change the online key? [y/n] (y)
         "New Online Key",  # Please enter a key name
+        "",  # Do you want to change unrecognized fields? (N)
     ]
 
 

--- a/tests/unit/cli/admin/metadata/test_update.py
+++ b/tests/unit/cli/admin/metadata/test_update.py
@@ -341,6 +341,7 @@ class TestMetadataUpdate:
             "JoeCocker's Key",  # Please enter a key name
             "y",  # Do you want to change the online key? [y/n] (y)
             "New Online Key",  # Please enter a key name
+            "",  # Do you want to change unrecognized fields? (N)
             f"{_PEMS / 'JH.ed25519'}",  # Please enter path to encrypted private key  # noqa
             f"{_PEMS / 'JJ.ecdsa'}",  # Please enter path to encrypted private key  # noqa
             f"{_PEMS / 'JC.rsa'}",  # Please enter path to encrypted private key  # noqa


### PR DESCRIPTION
# Description

This PR adds support for configuring `unrecognized_fields` in Root metadata via the CLI, as described in issue #608.

Reference issue:
https://github.com/repository-service-tuf/repository-service-tuf/issues/608

The API already supports unrecognized fields (see API PR #526), so this change focuses on enabling users to define and manage these fields during CLI workflows.

# Changes

* Added interactive prompt to configure `unrecognized_fields`

* Integrated into:

  * `rstuf admin ceremony`
  * `rstuf admin metadata update`

* Implemented validation to enforce format:
  `x-<vendor>-<name>`

* Ensured fields are preserved in Root metadata and included in the final JSON payload

# Behavior

* Users can:

  * add new custom fields
  * modify existing ones
  * clear previously set fields

* Invalid field names are rejected with clear error messages

# Testing

* Updated CLI unit tests to support new prompt flow
* Verified:

  * valid fields are accepted
  * invalid format is rejected
  * fields are preserved in metadata output

# Notes

* Minimal changes, aligned with existing CLI structure
* No breaking changes introduced
* Maintains compatibility with existing API behavior

# Type of change

* [x] New feature

# Additional requirements

* [x] Tests added

# Code of Conduct

* [x] I agree to follow this project's Code of Conduct
